### PR TITLE
removed token refresh subscription

### DIFF
--- a/vault/src/main/java/io/confluent/csid/config/provider/vault/VaultClientImpl.java
+++ b/vault/src/main/java/io/confluent/csid/config/provider/vault/VaultClientImpl.java
@@ -127,7 +127,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 class VaultClientImpl implements VaultClient {
@@ -161,16 +160,7 @@ class VaultClientImpl implements VaultClient {
     this.vaultStore.set(initialVault);
 
     if (result.ttl().isPresent() && result.ttl().get() > 0) {
-      if (result.authRenewable()) {
-        this.executorService.schedule(() -> {
-
-            },
-            result.ttl().get(),
-            TimeUnit.SECONDS
-        );
-      } else if (result.tokenRenewable()) {
-
-      }
+      log.debug("ctor() - AuthResult does have a ttl - ignoring.");
     } else {
       log.debug("ctor() - AuthResult does not have a ttl so not scheduling token refresh.");
     }


### PR DESCRIPTION
The empty token renewal subscription is causing 10s delay everytime the object is destroyed severely extending the component startup times (especially on connect worker where every single client object for every single connector instantiates and destroys it). I don;t see scenario where we actually need to token renewal so I'm proposing its removal. Please let me know what you think.