### PR TITLE
Update email reference in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,6 +14,6 @@ currently being supported with security updates.
 
 ## Reporting a Vulnerability
 
-To report a vulnerability, please notify [bugbounty@confluent.io](mailto:bugbounty@confluent.io)
+To report a vulnerability, please notify [security@confluent.io](mailto:security@confluent.io)
 
 If an issue is confirmed, a github issue will be created to help track progress with its resolution.


### PR DESCRIPTION
Updating email address reference from "bugbounty@confluent.io" to "security@confluent.io". 