### PR TITLE
Add aws-java-sdk-sts dependency for IAM role for service account auth support in Kubernetes

### DIFF
--- a/aws/pom.xml
+++ b/aws/pom.xml
@@ -156,6 +156,10 @@
             <artifactId>aws-java-sdk-secretsmanager</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sts</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.immutables</groupId>
             <artifactId>value</artifactId>
         </dependency>


### PR DESCRIPTION
## Issue

https://github.com/confluentinc/csid-secrets-providers/issues/142

## Changes

- Add aws-java-sdk-sts dependency

## Description
<!--- Describe your changes in detail -->
- Added the necessary sts dependency to the pom.xml in aws module of plugin.
>  According to AWS website, for application running in containers this dependency is required to use IRSA.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- When added the plugin to debezium-connect running as a pod in the cluster in order to retrieve secrets from AWS Secrets manager to be used in the connector previously I was getting AccessDenied despite attaching the service account with right permissions to the resource.
- Unable to use WebIdentityTokenCredentialsProvider auth in DefaultAWSCredentialProviderChain for authenticating debezium-connect pod running in the cluster to access secrets from AWS secrets manager despite having correct permissions.
- The relevant environment variable AWS_WEB_IDENTITY_TOKEN_FILE was evidently not took into consideration.

Found this from the logs:
```
DEBUG  ||  Unable to load credentials from WebIdentityTokenCredentialsProvider: com.amazonaws.SdkClientException: To use assume role profiles the aws-java-sdk-sts module must be on the class path.
```
- Debezium tries to access credentials at each level of the chain ad finally from EKSNodeRole and returns AccessDenied.
- When explicitly using an aws access key, secret key can retrieve correctly.
- aws-java-sdk-sts dependency was not added in the confluent csid-provider-aws plugin.
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
- Added the relevant sts dependency in aws module pom.xml.
- Packaged the module.
- Added the packaged plugin to debezium-connect plugin path.
- Previously receiving AccessDenied, was now able to successfully retrieve and use the secrets from AWS Secrets manager.
<!--- Include details of your testing environment, and the tests you ran to -->
## Environment
- Provider: Amazon EKS
- Kubernetes Version: v1.26.10
- Debezium connect - debezium/connect:1.9.3.Final
-  confluent- csid-provider-aws plugin - v1.0.8 (Latest)
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

NA

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
  - No change required.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
   - Existing test cases passed.