### PR TITLE
Updating vault library & kafka client

### DIFF
--- a/aws/pom.xml
+++ b/aws/pom.xml
@@ -162,6 +162,7 @@
         <dependency>
             <groupId>org.immutables</groupId>
             <artifactId>value</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/azure/pom.xml
+++ b/azure/pom.xml
@@ -166,6 +166,7 @@
         <dependency>
             <groupId>org.immutables</groupId>
             <artifactId>value</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/common-testing/pom.xml
+++ b/common-testing/pom.xml
@@ -38,6 +38,7 @@
         <dependency>
             <groupId>org.immutables</groupId>
             <artifactId>value</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.confluent.csid</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -17,6 +17,7 @@
         <dependency>
             <groupId>org.immutables</groupId>
             <artifactId>value</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.confluent.csid</groupId>

--- a/gcloud/pom.xml
+++ b/gcloud/pom.xml
@@ -162,6 +162,7 @@
         <dependency>
             <groupId>org.immutables</groupId>
             <artifactId>value</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/k8s/pom.xml
+++ b/k8s/pom.xml
@@ -140,6 +140,7 @@
         <dependency>
             <groupId>org.immutables</groupId>
             <artifactId>value</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
         <jackson.version>2.15.2</jackson.version>
         <junit.version>5.10.0</junit.version>
         <kafka-connect-style.version>[1.1.0,1.1.1000)</kafka-connect-style.version>
-        <kafka-clients.version>3.5.1</kafka-clients.version>
+        <kafka-clients.version>3.6.0</kafka-clients.version>
         <license-maven-plugin.version>3.0</license-maven-plugin.version>
         <logback.version>1.4.12</logback.version>
         <maven.checkstyle.version>3.3.0</maven.checkstyle.version>
@@ -218,9 +218,10 @@
             </dependency>
             <dependency>
                 <groupId>org.immutables</groupId>
-                <artifactId>value</artifactId>
+                <artifactId>bom</artifactId>
                 <version>${immutables.version}</version>
-                <scope>provided</scope>
+                <scope>import</scope>
+                <type>pom</type>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson</groupId>

--- a/vault/pom.xml
+++ b/vault/pom.xml
@@ -129,7 +129,7 @@
     </parent>
     <description>Secrets Provider for Hashicorp Vault</description>
     <properties>
-        <vault-java-driver.version>5.1.0</vault-java-driver.version>
+        <vault-java-driver.version>6.2.0</vault-java-driver.version>
     </properties>
     <dependencies>
         <dependency>
@@ -137,7 +137,7 @@
             <artifactId>csid-secrets-provider-common</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.bettercloud</groupId>
+            <groupId>io.github.jopenlibs</groupId>
             <artifactId>vault-java-driver</artifactId>
             <version>${vault-java-driver.version}</version>
         </dependency>

--- a/vault/pom.xml
+++ b/vault/pom.xml
@@ -148,6 +148,7 @@
         <dependency>
             <groupId>org.immutables</groupId>
             <artifactId>value</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.confluent.csid</groupId>

--- a/vault/src/main/java/io/confluent/csid/config/provider/vault/AuthHandler.java
+++ b/vault/src/main/java/io/confluent/csid/config/provider/vault/AuthHandler.java
@@ -117,10 +117,10 @@
  */
 package io.confluent.csid.config.provider.vault;
 
-import com.bettercloud.vault.Vault;
-import com.bettercloud.vault.VaultException;
-import com.bettercloud.vault.response.AuthResponse;
-import com.bettercloud.vault.response.LookupResponse;
+import io.github.jopenlibs.vault.Vault;
+import io.github.jopenlibs.vault.VaultException;
+import io.github.jopenlibs.vault.response.AuthResponse;
+import io.github.jopenlibs.vault.response.LookupResponse;
 import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/vault/src/main/java/io/confluent/csid/config/provider/vault/VaultClient.java
+++ b/vault/src/main/java/io/confluent/csid/config/provider/vault/VaultClient.java
@@ -117,9 +117,9 @@
  */
 package io.confluent.csid.config.provider.vault;
 
-import com.bettercloud.vault.VaultException;
-import com.bettercloud.vault.response.LogicalResponse;
 import io.confluent.csid.config.provider.common.SecretRequest;
+import io.github.jopenlibs.vault.VaultException;
+import io.github.jopenlibs.vault.response.LogicalResponse;
 
 interface VaultClient {
   LogicalResponse read(SecretRequest request) throws VaultException;

--- a/vault/src/main/java/io/confluent/csid/config/provider/vault/VaultClientImpl.java
+++ b/vault/src/main/java/io/confluent/csid/config/provider/vault/VaultClientImpl.java
@@ -117,11 +117,11 @@
  */
 package io.confluent.csid.config.provider.vault;
 
-import com.bettercloud.vault.Vault;
-import com.bettercloud.vault.VaultConfig;
-import com.bettercloud.vault.VaultException;
-import com.bettercloud.vault.response.LogicalResponse;
 import io.confluent.csid.config.provider.common.SecretRequest;
+import io.github.jopenlibs.vault.Vault;
+import io.github.jopenlibs.vault.VaultConfig;
+import io.github.jopenlibs.vault.VaultException;
+import io.github.jopenlibs.vault.response.LogicalResponse;
 import org.apache.kafka.common.config.ConfigException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -145,7 +145,7 @@ class VaultClientImpl implements VaultClient {
     log.info("ctor() - creating initial vault client");
 
     AuthHandler authHandler = AuthHandlers.get(config.authMethod);
-    Vault initialVault = new Vault(vaultConfig);
+    Vault initialVault = Vault.create(vaultConfig);
     AuthHandler.AuthResult result;
     try {
       result = authHandler.execute(config, initialVault);

--- a/vault/src/main/java/io/confluent/csid/config/provider/vault/VaultConfigProvider.java
+++ b/vault/src/main/java/io/confluent/csid/config/provider/vault/VaultConfigProvider.java
@@ -117,14 +117,14 @@
  */
 package io.confluent.csid.config.provider.vault;
 
-import com.bettercloud.vault.VaultException;
-import com.bettercloud.vault.response.LogicalResponse;
 import io.confluent.csid.config.provider.annotations.ConfigProviderKey;
 import io.confluent.csid.config.provider.annotations.Description;
 import io.confluent.csid.config.provider.annotations.DocumentationTip;
 import io.confluent.csid.config.provider.common.AbstractConfigProvider;
 import io.confluent.csid.config.provider.common.RetriableException;
 import io.confluent.csid.config.provider.common.SecretRequest;
+import io.github.jopenlibs.vault.VaultException;
+import io.github.jopenlibs.vault.response.LogicalResponse;
 import org.apache.kafka.common.config.ConfigDef;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/vault/src/main/java/io/confluent/csid/config/provider/vault/VaultConfigProviderConfig.java
+++ b/vault/src/main/java/io/confluent/csid/config/provider/vault/VaultConfigProviderConfig.java
@@ -117,15 +117,14 @@
  */
 package io.confluent.csid.config.provider.vault;
 
-
-import com.bettercloud.vault.EnvironmentLoader;
-import com.bettercloud.vault.SslConfig;
-import com.bettercloud.vault.VaultConfig;
-import com.bettercloud.vault.VaultException;
 import io.confluent.csid.config.provider.common.AbstractConfigProviderConfig;
 import io.confluent.csid.config.provider.common.config.ConfigKeyBuilder;
 import io.confluent.csid.config.provider.common.config.ConfigUtils;
 import io.confluent.csid.config.provider.common.config.Validators;
+import io.github.jopenlibs.vault.EnvironmentLoader;
+import io.github.jopenlibs.vault.SslConfig;
+import io.github.jopenlibs.vault.VaultConfig;
+import io.github.jopenlibs.vault.VaultException;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.types.Password;

--- a/vault/src/test/java/io/confluent/csid/config/provider/vault/LDAPVaultConfigProviderIT.java
+++ b/vault/src/test/java/io/confluent/csid/config/provider/vault/LDAPVaultConfigProviderIT.java
@@ -117,10 +117,10 @@
  */
 package io.confluent.csid.config.provider.vault;
 
-import com.bettercloud.vault.SslConfig;
-import com.bettercloud.vault.Vault;
-import com.bettercloud.vault.VaultConfig;
-import com.bettercloud.vault.VaultException;
+import io.github.jopenlibs.vault.SslConfig;
+import io.github.jopenlibs.vault.Vault;
+import io.github.jopenlibs.vault.VaultConfig;
+import io.github.jopenlibs.vault.VaultException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.testcontainers.containers.GenericContainer;
@@ -202,7 +202,7 @@ public class LDAPVaultConfigProviderIT extends VaultConfigProviderIT {
         .token(Constants.TOKEN)
         .sslConfig(config)
         .build();
-    this.vault = new Vault(vaultConfig);
+    this.vault = Vault.create(vaultConfig);
   }
 
   @AfterEach

--- a/vault/src/test/java/io/confluent/csid/config/provider/vault/TokenVaultConfigProviderIT.java
+++ b/vault/src/test/java/io/confluent/csid/config/provider/vault/TokenVaultConfigProviderIT.java
@@ -117,10 +117,10 @@
  */
 package io.confluent.csid.config.provider.vault;
 
-import com.bettercloud.vault.SslConfig;
-import com.bettercloud.vault.Vault;
-import com.bettercloud.vault.VaultConfig;
-import com.bettercloud.vault.VaultException;
+import io.github.jopenlibs.vault.SslConfig;
+import io.github.jopenlibs.vault.Vault;
+import io.github.jopenlibs.vault.VaultConfig;
+import io.github.jopenlibs.vault.VaultException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.testcontainers.vault.VaultContainer;
@@ -165,7 +165,7 @@ public class TokenVaultConfigProviderIT extends VaultConfigProviderIT {
         .token(Constants.TOKEN)
         .sslConfig(config)
         .build();
-    this.vault = new Vault(vaultConfig);
+    this.vault = Vault.create(vaultConfig);
   }
 
   @AfterEach

--- a/vault/src/test/java/io/confluent/csid/config/provider/vault/UserPassVaultConfigProviderIT.java
+++ b/vault/src/test/java/io/confluent/csid/config/provider/vault/UserPassVaultConfigProviderIT.java
@@ -117,10 +117,10 @@
  */
 package io.confluent.csid.config.provider.vault;
 
-import com.bettercloud.vault.SslConfig;
-import com.bettercloud.vault.Vault;
-import com.bettercloud.vault.VaultConfig;
-import com.bettercloud.vault.VaultException;
+import io.github.jopenlibs.vault.SslConfig;
+import io.github.jopenlibs.vault.Vault;
+import io.github.jopenlibs.vault.VaultConfig;
+import io.github.jopenlibs.vault.VaultException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.testcontainers.utility.MountableFile;
@@ -172,7 +172,7 @@ public class UserPassVaultConfigProviderIT extends VaultConfigProviderIT {
         .token(Constants.TOKEN)
         .sslConfig(config)
         .build();
-    this.vault = new Vault(vaultConfig);
+    this.vault = Vault.create(vaultConfig);
   }
 
   @AfterEach

--- a/vault/src/test/java/io/confluent/csid/config/provider/vault/VaultConfigProviderConfigTests.java
+++ b/vault/src/test/java/io/confluent/csid/config/provider/vault/VaultConfigProviderConfigTests.java
@@ -117,8 +117,8 @@
  */
 package io.confluent.csid.config.provider.vault;
 
-import com.bettercloud.vault.EnvironmentLoader;
-import com.bettercloud.vault.VaultConfig;
+import io.github.jopenlibs.vault.EnvironmentLoader;
+import io.github.jopenlibs.vault.VaultConfig;
 import org.apache.kafka.common.config.ConfigException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/vault/src/test/java/io/confluent/csid/config/provider/vault/VaultConfigProviderIT.java
+++ b/vault/src/test/java/io/confluent/csid/config/provider/vault/VaultConfigProviderIT.java
@@ -117,16 +117,15 @@
  */
 package io.confluent.csid.config.provider.vault;
 
-import com.bettercloud.vault.Vault;
-import com.bettercloud.vault.VaultException;
 import com.google.common.collect.ImmutableSet;
+import io.github.jopenlibs.vault.Vault;
+import io.github.jopenlibs.vault.VaultException;
 import org.apache.kafka.common.config.ConfigData;
 import org.apache.kafka.common.config.ConfigException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -136,13 +135,12 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 //@Compose(dockerComposePath = "docker-compose.yml", clusterHealthCheck = VaultClusterHealthCheck.class)
 public abstract class VaultConfigProviderIT {
 
-  public static final String HASHICORP_VAULT_DOCKER_IMAGE = "hashicorp/vault:1.13";
+  public static final String HASHICORP_VAULT_DOCKER_IMAGE = "hashicorp/vault:1.15";
   public static final String LDAP_DOCKER_IMAGE = "osixia/openldap:1.5.0";
 
   protected VaultConfigProvider configProvider;

--- a/vault/src/test/java/io/confluent/csid/config/provider/vault/VaultConfigProviderTests.java
+++ b/vault/src/test/java/io/confluent/csid/config/provider/vault/VaultConfigProviderTests.java
@@ -117,19 +117,17 @@
  */
 package io.confluent.csid.config.provider.vault;
 
-import com.bettercloud.vault.VaultException;
-import com.bettercloud.vault.api.Logical;
-import com.bettercloud.vault.response.LogicalResponse;
-import com.bettercloud.vault.rest.RestResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.csid.config.provider.common.AbstractConfigProviderConfig;
+import io.github.jopenlibs.vault.VaultException;
+import io.github.jopenlibs.vault.api.Logical;
+import io.github.jopenlibs.vault.response.LogicalResponse;
+import io.github.jopenlibs.vault.rest.RestResponse;
 import org.apache.kafka.common.config.ConfigData;
 import org.apache.kafka.common.config.ConfigException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.mockito.stubbing.OngoingStubbing;
 
 import java.util.LinkedHashMap;
@@ -139,9 +137,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class VaultConfigProviderTests {


### PR DESCRIPTION
## Description
Updating Vault Java library and Kafka Client

## Motivation and Context
The Vault Java Client used has been out of maintenance since 2019 and as from Hasihcorp's own reference pages - the new recommended vault library from https://developer.hashicorp.com/vault/api-docs/libraries has been changed to https://github.com/jopenlibs/vault-java-driver.  Most of the functions remain the same however creation of a new Vault is now Vault.create but performs the same functionality.

Kafka Client has been updated to 3.6.0

## How Has This Been Tested?
Unit and integration tests continue to pass on latest and greatest versions
All references to the Vault library have been changed due to classpath changes

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.