### PR TITLE
184 : fix use of AppRole with custom mount

### DIFF
--- a/vault/src/main/java/io/confluent/csid/config/provider/vault/AuthHandler.java
+++ b/vault/src/main/java/io/confluent/csid/config/provider/vault/AuthHandler.java
@@ -274,8 +274,8 @@ abstract class AuthHandler {
         log.trace("execute() - calling loginByAppRole('{}', '*****')", config.role);
         response = vault.auth().loginByAppRole(config.role, config.secret);
       } else {
-        log.trace("execute() - calling loginByUserPass('{}', ****, '{}')", config.username, config.mount);
-        response = vault.auth().loginByUserPass(config.username, config.password, config.mount);
+        log.trace("execute() - calling loginByAppRole('{}', '{}', ****)", config.mount, config.role);
+        response = vault.auth().loginByAppRole(config.mount, config.role, config.secret);
       }
       return result(response);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When we use vaultProvider with AppRole and custom mount, the authentication use UserPass instead of AppRole

## Motivation and Context
### Vault Provider

When using Vault provider, we need some configs like :

> vault.address = https://vault.xxxx.com
	vault.auth.method = AppRole
	**vault.auth.mount = approle-xxx**
	vault.auth.role = xxxxx
	vault.auth.secret = [hidden]
	vault.namespace = 
	vault.prefixpath = 
	vault.secrets.version = 2

but unfortunately, when we specify a custome **vault.auth.mount**, the java code force the use of **UserPass** login instead of **AppRole** in this [line](https://github.com/confluentinc/csid-secrets-providers/blob/5fea1bc67d059adad49c6b1bc66a2744bcda5d92/vault/src/main/java/io/confluent/csid/config/provider/vault/AuthHandler.java#L278)

this code

     public AuthResult execute(VaultConfigProviderConfig config, Vault vault) throws VaultException {
      AuthResponse response;
      if (isNullOrEmpty(config.mount)) {
        log.trace("execute() - calling loginByAppRole('{}', '*****')", config.role);
        response = vault.auth().loginByAppRole(config.role, config.secret);
      } else {
        log.trace("execute() - calling loginByUserPass('{}', ****, '{}')", config.username, config.mount);
        response = vault.auth().loginByUserPass(config.username, config.password, config.mount);
      }
      return result(response);
    }

should be replaced by this one

      public AuthResult execute(VaultConfigProviderConfig config, Vault vault) throws VaultException {
      AuthResponse response;

      if (isNullOrEmpty(config.mount)) {
        log.trace("execute() - calling loginByAppRole('{}', '*****')", config.role);
        response = vault.auth().loginByAppRole(config.role, config.secret);
      } else {
        log.trace("execute() - calling loginByAppRole('{}', '{}', ****)", config.mount, config.role);
        response = vault.auth().loginByAppRole( config.mount, config.role, config.secret);
      }
      return result(response);
    }

Issue : [184](https://github.com/confluentinc/csid-secrets-providers/issues/184)

## How Has This Been Tested?
Test in Progress

## Screenshots (if appropriate):
Before
![image](https://github.com/confluentinc/csid-secrets-providers/assets/9490956/9b7a1915-fb11-44ec-88dd-672230135068)

After
![image](https://github.com/confluentinc/csid-secrets-providers/assets/9490956/f88bf212-6f82-402f-91d6-029201664bc7)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.