### PR TITLE
implement secret.prefix configuration option

### DIFF
--- a/aws/src/main/java/io/confluent/csid/config/provider/aws/AppendSecretPrefixRequestHandler2.java
+++ b/aws/src/main/java/io/confluent/csid/config/provider/aws/AppendSecretPrefixRequestHandler2.java
@@ -1,3 +1,120 @@
+/**
+ *                     Copyright Confluent
+ *                     Confluent Community License Agreement
+ *                                 Version 1.0
+ *
+ * This Confluent Community License Agreement Version 1.0 (the “Agreement”) sets
+ * forth the terms on which Confluent, Inc. (“Confluent”) makes available certain
+ * software made available by Confluent under this Agreement (the “Software”).  BY
+ * INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY OF THE SOFTWARE,
+ * YOU AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE TO
+ * SUCH TERMS AND CONDITIONS, YOU MUST NOT USE THE SOFTWARE.  IF YOU ARE RECEIVING
+ * THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU
+ * HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS
+ * AGREEMENT ON BEHALF OF SUCH ENTITY.  “Licensee” means you, an individual, or
+ * the entity on whose behalf you are receiving the Software.
+ *
+ *    1. LICENSE GRANT AND CONDITIONS.
+ *
+ *       1.1 License.  Subject to the terms and conditions of this Agreement,
+ *       Confluent hereby grants to Licensee a non-exclusive, royalty-free,
+ *       worldwide, non-transferable, non-sublicenseable license during the term
+ *       of this Agreement to: (a) use the Software; (b) prepare modifications and
+ *       derivative works of the Software; (c) distribute the Software (including
+ *       without limitation in source code or object code form); and (d) reproduce
+ *       copies of the Software (the “License”).  Licensee is not granted the
+ *       right to, and Licensee shall not, exercise the License for an Excluded
+ *       Purpose.  For purposes of this Agreement, “Excluded Purpose” means making
+ *       available any software-as-a-service, platform-as-a-service,
+ *       infrastructure-as-a-service or other similar online service that competes
+ *       with Confluent products or services that provide the Software.
+ *
+ *       1.2 Conditions.  In consideration of the License, Licensee’s distribution
+ *       of the Software is subject to the following conditions:
+ *
+ *          (a) Licensee must cause any Software modified by Licensee to carry
+ *          prominent notices stating that Licensee modified the Software.
+ *
+ *          (b) On each Software copy, Licensee shall reproduce and not remove or
+ *          alter all Confluent or third party copyright or other proprietary
+ *          notices contained in the Software, and Licensee must provide the
+ *          notice below with each copy.
+ *
+ *             “This software is made available by Confluent, Inc., under the
+ *             terms of the Confluent Community License Agreement, Version 1.0
+ *             located at http://www.confluent.io/confluent-community-license.  BY
+ *             INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY OF
+ *             THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.”
+ *
+ *       1.3 Licensee Modifications.  Licensee may add its own copyright notices
+ *       to modifications made by Licensee and may provide additional or different
+ *       license terms and conditions for use, reproduction, or distribution of
+ *       Licensee’s modifications.  While redistributing the Software or
+ *       modifications thereof, Licensee may choose to offer, for a fee or free of
+ *       charge, support, warranty, indemnity, or other obligations. Licensee, and
+ *       not Confluent, will be responsible for any such obligations.
+ *
+ *       1.4 No Sublicensing.  The License does not include the right to
+ *       sublicense the Software, however, each recipient to which Licensee
+ *       provides the Software may exercise the Licenses so long as such recipient
+ *       agrees to the terms and conditions of this Agreement.
+ *
+ *    2. TERM AND TERMINATION.  This Agreement will continue unless and until
+ *    earlier terminated as set forth herein.  If Licensee breaches any of its
+ *    conditions or obligations under this Agreement, this Agreement will
+ *    terminate automatically and the License will terminate automatically and
+ *    permanently.
+ *
+ *    3. INTELLECTUAL PROPERTY.  As between the parties, Confluent will retain all
+ *    right, title, and interest in the Software, and all intellectual property
+ *    rights therein.  Confluent hereby reserves all rights not expressly granted
+ *    to Licensee in this Agreement.  Confluent hereby reserves all rights in its
+ *    trademarks and service marks, and no licenses therein are granted in this
+ *    Agreement.
+ *
+ *    4. DISCLAIMER.  CONFLUENT HEREBY DISCLAIMS ANY AND ALL WARRANTIES AND
+ *    CONDITIONS, EXPRESS, IMPLIED, STATUTORY, OR OTHERWISE, AND SPECIFICALLY
+ *    DISCLAIMS ANY WARRANTY OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+ *    PURPOSE, WITH RESPECT TO THE SOFTWARE.
+ *
+ *    5. LIMITATION OF LIABILITY.  CONFLUENT WILL NOT BE LIABLE FOR ANY DAMAGES OF
+ *    ANY KIND, INCLUDING BUT NOT LIMITED TO, LOST PROFITS OR ANY CONSEQUENTIAL,
+ *    SPECIAL, INCIDENTAL, INDIRECT, OR DIRECT DAMAGES, HOWEVER CAUSED AND ON ANY
+ *    THEORY OF LIABILITY, ARISING OUT OF THIS AGREEMENT.  THE FOREGOING SHALL
+ *    APPLY TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+ *
+ *    6.GENERAL.
+ *
+ *       6.1 Governing Law. This Agreement will be governed by and interpreted in
+ *       accordance with the laws of the state of California, without reference to
+ *       its conflict of laws principles.  If Licensee is located within the
+ *       United States, all disputes arising out of this Agreement are subject to
+ *       the exclusive jurisdiction of courts located in Santa Clara County,
+ *       California. USA.  If Licensee is located outside of the United States,
+ *       any dispute, controversy or claim arising out of or relating to this
+ *       Agreement will be referred to and finally determined by arbitration in
+ *       accordance with the JAMS International Arbitration Rules.  The tribunal
+ *       will consist of one arbitrator.  The place of arbitration will be Palo
+ *       Alto, California. The language to be used in the arbitral proceedings
+ *       will be English.  Judgment upon the award rendered by the arbitrator may
+ *       be entered in any court having jurisdiction thereof.
+ *
+ *       6.2 Assignment.  Licensee is not authorized to assign its rights under
+ *       this Agreement to any third party. Confluent may freely assign its rights
+ *       under this Agreement to any third party.
+ *
+ *       6.3 Other.  This Agreement is the entire agreement between the parties
+ *       regarding the subject matter hereof.  No amendment or modification of
+ *       this Agreement will be valid or binding upon the parties unless made in
+ *       writing and signed by the duly authorized representatives of both
+ *       parties.  In the event that any provision, including without limitation
+ *       any condition, of this Agreement is held to be unenforceable, this
+ *       Agreement and all licenses and rights granted hereunder will immediately
+ *       terminate.  Waiver by Confluent of a breach of any provision of this
+ *       Agreement or the failure by Confluent to exercise any right hereunder
+ *       will not be construed as a waiver of any subsequent breach of that right
+ *       or as a waiver of any other right.
+ */
 package io.confluent.csid.config.provider.aws;
 
 import com.amazonaws.AmazonWebServiceRequest;
@@ -5,16 +122,16 @@ import com.amazonaws.handlers.RequestHandler2;
 import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
 
 class AppendSecretPrefixRequestHandler2 extends RequestHandler2 {
-    private final String prefix;
+  private final String prefix;
 
-    public AppendSecretPrefixRequestHandler2(String prefix) {
-        this.prefix = prefix;
-    }
+  public AppendSecretPrefixRequestHandler2(String prefix) {
+    this.prefix = prefix;
+  }
 
-    @Override
-    public AmazonWebServiceRequest beforeExecution(AmazonWebServiceRequest request) {
-        GetSecretValueRequest local = ((GetSecretValueRequest) request);
-        local.setSecretId(prefix + local.getSecretId());
-        return local;
-    }
+  @Override
+  public AmazonWebServiceRequest beforeExecution(AmazonWebServiceRequest request) {
+    GetSecretValueRequest local = ((GetSecretValueRequest) request);
+    local.setSecretId(prefix + local.getSecretId());
+    return local;
+  }
 }

--- a/aws/src/main/java/io/confluent/csid/config/provider/aws/AppendSecretPrefixRequestHandler2.java
+++ b/aws/src/main/java/io/confluent/csid/config/provider/aws/AppendSecretPrefixRequestHandler2.java
@@ -1,0 +1,20 @@
+package io.confluent.csid.config.provider.aws;
+
+import com.amazonaws.AmazonWebServiceRequest;
+import com.amazonaws.handlers.RequestHandler2;
+import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
+
+class AppendSecretPrefixRequestHandler2 extends RequestHandler2 {
+    private final String prefix;
+
+    public AppendSecretPrefixRequestHandler2(String prefix) {
+        this.prefix = prefix;
+    }
+
+    @Override
+    public AmazonWebServiceRequest beforeExecution(AmazonWebServiceRequest request) {
+        GetSecretValueRequest local = ((GetSecretValueRequest) request);
+        local.setSecretId(prefix + local.getSecretId());
+        return local;
+    }
+}

--- a/aws/src/main/java/io/confluent/csid/config/provider/aws/SecretsManagerFactoryImpl.java
+++ b/aws/src/main/java/io/confluent/csid/config/provider/aws/SecretsManagerFactoryImpl.java
@@ -124,6 +124,11 @@ import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
 class SecretsManagerFactoryImpl implements SecretsManagerFactory {
   @Override
   public AWSSecretsManager create(SecretsManagerConfigProviderConfig config) {
+    AWSSecretsManagerClientBuilder builder = configure(config);
+    return builder.build();
+  }
+
+  protected AWSSecretsManagerClientBuilder configure(SecretsManagerConfigProviderConfig config) {
     AWSSecretsManagerClientBuilder builder = AWSSecretsManagerClientBuilder.standard();
 
     if (null != config.region && !config.region.isEmpty()) {
@@ -132,7 +137,9 @@ class SecretsManagerFactoryImpl implements SecretsManagerFactory {
     if (null != config.credentials) {
       builder = builder.withCredentials(new AWSStaticCredentialsProvider(config.credentials));
     }
-
-    return builder.build();
+    if (null != config.prefix) {
+      builder = builder.withRequestHandlers(new AppendSecretPrefixRequestHandler2(config.prefix));
+    }
+    return builder;
   }
 }

--- a/aws/src/test/java/io/confluent/csid/config/provider/aws/AppendSecretPrefixRequestHandler2Test.java
+++ b/aws/src/test/java/io/confluent/csid/config/provider/aws/AppendSecretPrefixRequestHandler2Test.java
@@ -1,3 +1,120 @@
+/**
+ *                     Copyright Confluent
+ *                     Confluent Community License Agreement
+ *                                 Version 1.0
+ *
+ * This Confluent Community License Agreement Version 1.0 (the “Agreement”) sets
+ * forth the terms on which Confluent, Inc. (“Confluent”) makes available certain
+ * software made available by Confluent under this Agreement (the “Software”).  BY
+ * INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY OF THE SOFTWARE,
+ * YOU AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE TO
+ * SUCH TERMS AND CONDITIONS, YOU MUST NOT USE THE SOFTWARE.  IF YOU ARE RECEIVING
+ * THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU
+ * HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS
+ * AGREEMENT ON BEHALF OF SUCH ENTITY.  “Licensee” means you, an individual, or
+ * the entity on whose behalf you are receiving the Software.
+ *
+ *    1. LICENSE GRANT AND CONDITIONS.
+ *
+ *       1.1 License.  Subject to the terms and conditions of this Agreement,
+ *       Confluent hereby grants to Licensee a non-exclusive, royalty-free,
+ *       worldwide, non-transferable, non-sublicenseable license during the term
+ *       of this Agreement to: (a) use the Software; (b) prepare modifications and
+ *       derivative works of the Software; (c) distribute the Software (including
+ *       without limitation in source code or object code form); and (d) reproduce
+ *       copies of the Software (the “License”).  Licensee is not granted the
+ *       right to, and Licensee shall not, exercise the License for an Excluded
+ *       Purpose.  For purposes of this Agreement, “Excluded Purpose” means making
+ *       available any software-as-a-service, platform-as-a-service,
+ *       infrastructure-as-a-service or other similar online service that competes
+ *       with Confluent products or services that provide the Software.
+ *
+ *       1.2 Conditions.  In consideration of the License, Licensee’s distribution
+ *       of the Software is subject to the following conditions:
+ *
+ *          (a) Licensee must cause any Software modified by Licensee to carry
+ *          prominent notices stating that Licensee modified the Software.
+ *
+ *          (b) On each Software copy, Licensee shall reproduce and not remove or
+ *          alter all Confluent or third party copyright or other proprietary
+ *          notices contained in the Software, and Licensee must provide the
+ *          notice below with each copy.
+ *
+ *             “This software is made available by Confluent, Inc., under the
+ *             terms of the Confluent Community License Agreement, Version 1.0
+ *             located at http://www.confluent.io/confluent-community-license.  BY
+ *             INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY OF
+ *             THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.”
+ *
+ *       1.3 Licensee Modifications.  Licensee may add its own copyright notices
+ *       to modifications made by Licensee and may provide additional or different
+ *       license terms and conditions for use, reproduction, or distribution of
+ *       Licensee’s modifications.  While redistributing the Software or
+ *       modifications thereof, Licensee may choose to offer, for a fee or free of
+ *       charge, support, warranty, indemnity, or other obligations. Licensee, and
+ *       not Confluent, will be responsible for any such obligations.
+ *
+ *       1.4 No Sublicensing.  The License does not include the right to
+ *       sublicense the Software, however, each recipient to which Licensee
+ *       provides the Software may exercise the Licenses so long as such recipient
+ *       agrees to the terms and conditions of this Agreement.
+ *
+ *    2. TERM AND TERMINATION.  This Agreement will continue unless and until
+ *    earlier terminated as set forth herein.  If Licensee breaches any of its
+ *    conditions or obligations under this Agreement, this Agreement will
+ *    terminate automatically and the License will terminate automatically and
+ *    permanently.
+ *
+ *    3. INTELLECTUAL PROPERTY.  As between the parties, Confluent will retain all
+ *    right, title, and interest in the Software, and all intellectual property
+ *    rights therein.  Confluent hereby reserves all rights not expressly granted
+ *    to Licensee in this Agreement.  Confluent hereby reserves all rights in its
+ *    trademarks and service marks, and no licenses therein are granted in this
+ *    Agreement.
+ *
+ *    4. DISCLAIMER.  CONFLUENT HEREBY DISCLAIMS ANY AND ALL WARRANTIES AND
+ *    CONDITIONS, EXPRESS, IMPLIED, STATUTORY, OR OTHERWISE, AND SPECIFICALLY
+ *    DISCLAIMS ANY WARRANTY OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+ *    PURPOSE, WITH RESPECT TO THE SOFTWARE.
+ *
+ *    5. LIMITATION OF LIABILITY.  CONFLUENT WILL NOT BE LIABLE FOR ANY DAMAGES OF
+ *    ANY KIND, INCLUDING BUT NOT LIMITED TO, LOST PROFITS OR ANY CONSEQUENTIAL,
+ *    SPECIAL, INCIDENTAL, INDIRECT, OR DIRECT DAMAGES, HOWEVER CAUSED AND ON ANY
+ *    THEORY OF LIABILITY, ARISING OUT OF THIS AGREEMENT.  THE FOREGOING SHALL
+ *    APPLY TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+ *
+ *    6.GENERAL.
+ *
+ *       6.1 Governing Law. This Agreement will be governed by and interpreted in
+ *       accordance with the laws of the state of California, without reference to
+ *       its conflict of laws principles.  If Licensee is located within the
+ *       United States, all disputes arising out of this Agreement are subject to
+ *       the exclusive jurisdiction of courts located in Santa Clara County,
+ *       California. USA.  If Licensee is located outside of the United States,
+ *       any dispute, controversy or claim arising out of or relating to this
+ *       Agreement will be referred to and finally determined by arbitration in
+ *       accordance with the JAMS International Arbitration Rules.  The tribunal
+ *       will consist of one arbitrator.  The place of arbitration will be Palo
+ *       Alto, California. The language to be used in the arbitral proceedings
+ *       will be English.  Judgment upon the award rendered by the arbitrator may
+ *       be entered in any court having jurisdiction thereof.
+ *
+ *       6.2 Assignment.  Licensee is not authorized to assign its rights under
+ *       this Agreement to any third party. Confluent may freely assign its rights
+ *       under this Agreement to any third party.
+ *
+ *       6.3 Other.  This Agreement is the entire agreement between the parties
+ *       regarding the subject matter hereof.  No amendment or modification of
+ *       this Agreement will be valid or binding upon the parties unless made in
+ *       writing and signed by the duly authorized representatives of both
+ *       parties.  In the event that any provision, including without limitation
+ *       any condition, of this Agreement is held to be unenforceable, this
+ *       Agreement and all licenses and rights granted hereunder will immediately
+ *       terminate.  Waiver by Confluent of a breach of any provision of this
+ *       Agreement or the failure by Confluent to exercise any right hereunder
+ *       will not be construed as a waiver of any subsequent breach of that right
+ *       or as a waiver of any other right.
+ */
 package io.confluent.csid.config.provider.aws;
 
 import com.amazonaws.AmazonWebServiceRequest;

--- a/aws/src/test/java/io/confluent/csid/config/provider/aws/AppendSecretPrefixRequestHandler2Test.java
+++ b/aws/src/test/java/io/confluent/csid/config/provider/aws/AppendSecretPrefixRequestHandler2Test.java
@@ -1,0 +1,35 @@
+package io.confluent.csid.config.provider.aws;
+
+import com.amazonaws.AmazonWebServiceRequest;
+import com.amazonaws.services.secretsmanager.model.GetSecretValueRequest;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AppendSecretPrefixRequestHandler2Test {
+    @Test
+    public void addsPrefix() {
+        String prefix = "test/prefix/";
+        String secretId = "primaryId";
+        AppendSecretPrefixRequestHandler2 handler = new AppendSecretPrefixRequestHandler2(prefix);
+        GetSecretValueRequest request = new GetSecretValueRequest();
+        request = request.withSecretId(secretId);
+
+        AmazonWebServiceRequest expected = request.withSecretId(prefix + secretId);
+        AmazonWebServiceRequest updated = handler.beforeExecution(request);
+
+        assertEquals(expected, updated);
+    }
+
+    @Test
+    public void retainsOtherAttributes() {
+        String secretId = "primaryId";
+        AppendSecretPrefixRequestHandler2 handler = new AppendSecretPrefixRequestHandler2("");
+        GetSecretValueRequest request = new GetSecretValueRequest();
+        request = request.withSecretId(secretId).withVersionStage("production").withVersionId("v1.2.3");
+
+        AmazonWebServiceRequest updated = handler.beforeExecution(request);
+
+        assertEquals(request, updated);
+    }
+}

--- a/aws/src/test/java/io/confluent/csid/config/provider/aws/SecretsManagerConfigProviderTest.java
+++ b/aws/src/test/java/io/confluent/csid/config/provider/aws/SecretsManagerConfigProviderTest.java
@@ -166,6 +166,14 @@ public class SecretsManagerConfigProviderTest {
   }
 
   @Test
+  public void someTest() {
+    Map<String, ?> settings = ImmutableMap.of("secret.prefix", "some/prefix/", "aws.access.key", "<ACCESS_KEY>", "aws.secret.key.id", "<SECRET_KEY_ID>");
+    SecretsManagerConfigProvider provider = new SecretsManagerConfigProvider();
+    provider.configure(settings);
+    provider.get("secret-id");
+  }
+
+  @Test
   public void notFound() {
     Throwable expected = new ResourceNotFoundException("Resource 'not/found' was not found.");
     when(secretsManager.getSecretValue(any())).thenThrow(expected);

--- a/aws/src/test/java/io/confluent/csid/config/provider/aws/SecretsManagerConfigProviderTest.java
+++ b/aws/src/test/java/io/confluent/csid/config/provider/aws/SecretsManagerConfigProviderTest.java
@@ -166,14 +166,6 @@ public class SecretsManagerConfigProviderTest {
   }
 
   @Test
-  public void someTest() {
-    Map<String, ?> settings = ImmutableMap.of("secret.prefix", "some/prefix/", "aws.access.key", "<ACCESS_KEY>", "aws.secret.key.id", "<SECRET_KEY_ID>");
-    SecretsManagerConfigProvider provider = new SecretsManagerConfigProvider();
-    provider.configure(settings);
-    provider.get("secret-id");
-  }
-
-  @Test
   public void notFound() {
     Throwable expected = new ResourceNotFoundException("Resource 'not/found' was not found.");
     when(secretsManager.getSecretValue(any())).thenThrow(expected);

--- a/aws/src/test/java/io/confluent/csid/config/provider/aws/SecretsManagerFactoryImplTest.java
+++ b/aws/src/test/java/io/confluent/csid/config/provider/aws/SecretsManagerFactoryImplTest.java
@@ -1,3 +1,120 @@
+/**
+ *                     Copyright Confluent
+ *                     Confluent Community License Agreement
+ *                                 Version 1.0
+ *
+ * This Confluent Community License Agreement Version 1.0 (the “Agreement”) sets
+ * forth the terms on which Confluent, Inc. (“Confluent”) makes available certain
+ * software made available by Confluent under this Agreement (the “Software”).  BY
+ * INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY OF THE SOFTWARE,
+ * YOU AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE TO
+ * SUCH TERMS AND CONDITIONS, YOU MUST NOT USE THE SOFTWARE.  IF YOU ARE RECEIVING
+ * THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU
+ * HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS
+ * AGREEMENT ON BEHALF OF SUCH ENTITY.  “Licensee” means you, an individual, or
+ * the entity on whose behalf you are receiving the Software.
+ *
+ *    1. LICENSE GRANT AND CONDITIONS.
+ *
+ *       1.1 License.  Subject to the terms and conditions of this Agreement,
+ *       Confluent hereby grants to Licensee a non-exclusive, royalty-free,
+ *       worldwide, non-transferable, non-sublicenseable license during the term
+ *       of this Agreement to: (a) use the Software; (b) prepare modifications and
+ *       derivative works of the Software; (c) distribute the Software (including
+ *       without limitation in source code or object code form); and (d) reproduce
+ *       copies of the Software (the “License”).  Licensee is not granted the
+ *       right to, and Licensee shall not, exercise the License for an Excluded
+ *       Purpose.  For purposes of this Agreement, “Excluded Purpose” means making
+ *       available any software-as-a-service, platform-as-a-service,
+ *       infrastructure-as-a-service or other similar online service that competes
+ *       with Confluent products or services that provide the Software.
+ *
+ *       1.2 Conditions.  In consideration of the License, Licensee’s distribution
+ *       of the Software is subject to the following conditions:
+ *
+ *          (a) Licensee must cause any Software modified by Licensee to carry
+ *          prominent notices stating that Licensee modified the Software.
+ *
+ *          (b) On each Software copy, Licensee shall reproduce and not remove or
+ *          alter all Confluent or third party copyright or other proprietary
+ *          notices contained in the Software, and Licensee must provide the
+ *          notice below with each copy.
+ *
+ *             “This software is made available by Confluent, Inc., under the
+ *             terms of the Confluent Community License Agreement, Version 1.0
+ *             located at http://www.confluent.io/confluent-community-license.  BY
+ *             INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY OF
+ *             THE SOFTWARE, YOU AGREE TO THE TERMS OF SUCH LICENSE AGREEMENT.”
+ *
+ *       1.3 Licensee Modifications.  Licensee may add its own copyright notices
+ *       to modifications made by Licensee and may provide additional or different
+ *       license terms and conditions for use, reproduction, or distribution of
+ *       Licensee’s modifications.  While redistributing the Software or
+ *       modifications thereof, Licensee may choose to offer, for a fee or free of
+ *       charge, support, warranty, indemnity, or other obligations. Licensee, and
+ *       not Confluent, will be responsible for any such obligations.
+ *
+ *       1.4 No Sublicensing.  The License does not include the right to
+ *       sublicense the Software, however, each recipient to which Licensee
+ *       provides the Software may exercise the Licenses so long as such recipient
+ *       agrees to the terms and conditions of this Agreement.
+ *
+ *    2. TERM AND TERMINATION.  This Agreement will continue unless and until
+ *    earlier terminated as set forth herein.  If Licensee breaches any of its
+ *    conditions or obligations under this Agreement, this Agreement will
+ *    terminate automatically and the License will terminate automatically and
+ *    permanently.
+ *
+ *    3. INTELLECTUAL PROPERTY.  As between the parties, Confluent will retain all
+ *    right, title, and interest in the Software, and all intellectual property
+ *    rights therein.  Confluent hereby reserves all rights not expressly granted
+ *    to Licensee in this Agreement.  Confluent hereby reserves all rights in its
+ *    trademarks and service marks, and no licenses therein are granted in this
+ *    Agreement.
+ *
+ *    4. DISCLAIMER.  CONFLUENT HEREBY DISCLAIMS ANY AND ALL WARRANTIES AND
+ *    CONDITIONS, EXPRESS, IMPLIED, STATUTORY, OR OTHERWISE, AND SPECIFICALLY
+ *    DISCLAIMS ANY WARRANTY OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+ *    PURPOSE, WITH RESPECT TO THE SOFTWARE.
+ *
+ *    5. LIMITATION OF LIABILITY.  CONFLUENT WILL NOT BE LIABLE FOR ANY DAMAGES OF
+ *    ANY KIND, INCLUDING BUT NOT LIMITED TO, LOST PROFITS OR ANY CONSEQUENTIAL,
+ *    SPECIAL, INCIDENTAL, INDIRECT, OR DIRECT DAMAGES, HOWEVER CAUSED AND ON ANY
+ *    THEORY OF LIABILITY, ARISING OUT OF THIS AGREEMENT.  THE FOREGOING SHALL
+ *    APPLY TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+ *
+ *    6.GENERAL.
+ *
+ *       6.1 Governing Law. This Agreement will be governed by and interpreted in
+ *       accordance with the laws of the state of California, without reference to
+ *       its conflict of laws principles.  If Licensee is located within the
+ *       United States, all disputes arising out of this Agreement are subject to
+ *       the exclusive jurisdiction of courts located in Santa Clara County,
+ *       California. USA.  If Licensee is located outside of the United States,
+ *       any dispute, controversy or claim arising out of or relating to this
+ *       Agreement will be referred to and finally determined by arbitration in
+ *       accordance with the JAMS International Arbitration Rules.  The tribunal
+ *       will consist of one arbitrator.  The place of arbitration will be Palo
+ *       Alto, California. The language to be used in the arbitral proceedings
+ *       will be English.  Judgment upon the award rendered by the arbitrator may
+ *       be entered in any court having jurisdiction thereof.
+ *
+ *       6.2 Assignment.  Licensee is not authorized to assign its rights under
+ *       this Agreement to any third party. Confluent may freely assign its rights
+ *       under this Agreement to any third party.
+ *
+ *       6.3 Other.  This Agreement is the entire agreement between the parties
+ *       regarding the subject matter hereof.  No amendment or modification of
+ *       this Agreement will be valid or binding upon the parties unless made in
+ *       writing and signed by the duly authorized representatives of both
+ *       parties.  In the event that any provision, including without limitation
+ *       any condition, of this Agreement is held to be unenforceable, this
+ *       Agreement and all licenses and rights granted hereunder will immediately
+ *       terminate.  Waiver by Confluent of a breach of any provision of this
+ *       Agreement or the failure by Confluent to exercise any right hereunder
+ *       will not be construed as a waiver of any subsequent breach of that right
+ *       or as a waiver of any other right.
+ */
 package io.confluent.csid.config.provider.aws;
 
 import com.amazonaws.auth.AWSCredentialsProvider;

--- a/aws/src/test/java/io/confluent/csid/config/provider/aws/SecretsManagerFactoryImplTest.java
+++ b/aws/src/test/java/io/confluent/csid/config/provider/aws/SecretsManagerFactoryImplTest.java
@@ -1,0 +1,55 @@
+package io.confluent.csid.config.provider.aws;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.handlers.RequestHandler2;
+import com.amazonaws.services.secretsmanager.AWSSecretsManagerClientBuilder;
+import com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+class SecretsManagerFactoryImplTest  {
+    private AWSSecretsManagerClientBuilder builderWithConfig(Map<String, ?> settings) {
+        SecretsManagerConfigProviderConfig config = new SecretsManagerConfigProviderConfig(settings);
+        SecretsManagerFactoryImpl factory = new SecretsManagerFactoryImpl();
+        return factory.configure(config);
+    }
+
+    @Test
+    public void addsRegion() {
+        String region = "eu-west-1";
+        Map<String, ?> settings = ImmutableMap.of("aws.region", region);
+
+        AWSSecretsManagerClientBuilder builder = builderWithConfig(settings);
+
+        assertEquals(region, builder.getRegion());
+    }
+
+    @Test
+    public void addsCredentials() {
+        String expectedAccessKey = "test_access_key";
+        String expectedSecretKey = "some_test_key";
+        Map<String, ?> settings = ImmutableMap.of("aws.access.key", expectedAccessKey, "aws.secret.key.id", expectedSecretKey);
+
+        AWSSecretsManagerClientBuilder builder = builderWithConfig(settings);
+
+        AWSCredentialsProvider credentialsProvider = builder.getCredentials();
+        assertInstanceOf(AWSStaticCredentialsProvider.class, credentialsProvider);
+    }
+
+    @Test
+    public void addsPrefixHandler() {
+        Map<String, ?> settings = ImmutableMap.of("secret.prefix", "test/prefix/");
+
+        AWSSecretsManagerClientBuilder builder = builderWithConfig(settings);
+
+        List<RequestHandler2> requestHandlers = builder.getRequestHandlers();
+        assertEquals(1, requestHandlers.size());
+        assertInstanceOf(AppendSecretPrefixRequestHandler2.class, requestHandlers.get(0));
+    }
+}


### PR DESCRIPTION
## Description
Implement the option of the `secret.prefix` as a custom `RequestHandler2` for the `AWSSecretManagerClient`. This implements the perceived functionality in the configuration, that a general prefix can be passed to the config provider.

## Motivation and Context
This change is requested, since the provider documentation claims this functionality is already present.
The issue has been raised in #210 

## How Has This Been Tested?
There are unit test that cover the functionality of the RequestHandler and the ConfigurationImpl.
Additionally, I've run a local test with actual AWS credentials to validate expected behavior.


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.