### PR TITLE
removing license plugin due to potential vulnerability at build due t…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,6 @@
         <junit.version>5.10.0</junit.version>
         <kafka-connect-style.version>[1.1.0,1.1.1000)</kafka-connect-style.version>
         <kafka-clients.version>3.6.0</kafka-clients.version>
-        <license-maven-plugin.version>3.0</license-maven-plugin.version>
         <logback.version>1.4.14</logback.version>
         <maven.checkstyle.version>3.3.0</maven.checkstyle.version>
         <maven.release.version>3.0.1</maven.release.version>
@@ -346,41 +345,6 @@
             </plugins>
         </pluginManagement>
         <plugins>
-            <plugin>
-                <groupId>com.mycila</groupId>
-                <artifactId>license-maven-plugin</artifactId>
-                <version>${license-maven-plugin.version}</version>
-                <configuration>
-                    <header>${license.path}</header>
-                    <properties>
-                        <owner>Confluent, Inc</owner>
-                    </properties>
-                    <excludes>
-                        <exclude>**/README</exclude>
-                        <exclude>LICENSE</exclude>
-                        <exclude>src/test/resources/**</exclude>
-                        <exclude>src/main/resources/**</exclude>
-                        <exclude>src/assembly/**</exclude>
-                        <exclude>docs/</exclude>
-                        <exclude>astrodocs/</exclude>
-                        <exclude>.mvn/</exclude>
-                        <exclude>mvnw</exclude>
-                        <exclude>mvnw.cmd</exclude>
-                        <exclude>.github/</exclude>
-                        <exclude>Jenkinsfile</exclude>
-                        <exclude>venv/</exclude>
-                    </excludes>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>check-source</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
## Description
Removing the license plugin due to potential to be exploitable by MavenGate.  This is only used at build time and thus doesn't require a release to be created.  If the repo is remediated by registering its domain we can add this back in again.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Removing the check at build.  Does not impact any functionality of code.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.