### PR TITLE
MINOR: Specify the use of vault.prefixpath in documentation

### DIFF
--- a/astrodocs/src/content/docs/guides/plugins/hashicorp_vault.md
+++ b/astrodocs/src/content/docs/guides/plugins/hashicorp_vault.md
@@ -18,7 +18,7 @@ This config provider is used to retrieve secrets from the Hashicorp Vault.
 
 #### General
 
-```java
+```properties
 retry.count
 ```
 The number of attempts to retrieve a secret from the upstream secret store.
@@ -28,7 +28,7 @@ The number of attempts to retrieve a secret from the upstream secret store.
 * Valid Values:
 * Importance: LOW
 
-```java
+```properties
 retry.interval.seconds
 ```
 The amount of time in seconds to wait between each attempt to retrieve a secret form the upstream secret store.
@@ -38,7 +38,7 @@ The amount of time in seconds to wait between each attempt to retrieve a secret 
 * Valid Values:
 * Importance: LOW
 
-```java
+```properties
 thread.count
 ```
 The number of threads to use when retrieving secrets and executing subscription callbacks.
@@ -48,7 +48,7 @@ The number of threads to use when retrieving secrets and executing subscription 
 * Valid Values:
 * Importance: LOW
 
-```java
+```properties
 timeout.seconds
 ```
 The amount of time in seconds to wait before timing out a call to retrieve a secret from the upstream secret store. The total timeout of `get(path)` and `get(path, keys)` will be `retry.count * timeout.seconds`. For example if `timeout.seconds = 30` and `retry.count = 3` then `get(path)` and `get(path, keys)` will block for 90 seconds.
@@ -58,7 +58,7 @@ The amount of time in seconds to wait before timing out a call to retrieve a sec
 * Valid Values:
 * Importance: LOW
 
-```java
+```properties
 vault.namespace
 ```
 Sets a global namespace to the Vault server instance, if desired.
@@ -68,7 +68,7 @@ Sets a global namespace to the Vault server instance, if desired.
 * Valid Values:
 * Importance: LOW
 
-```java
+```properties
 polling.enabled
 ```
 Determines if the config provider supports polling the upstream secret stores for changes. If disabled the methods `subscribe`, `unsubscribe`, and `unsubscribeAll` will throw a UnsupportedOperationException.
@@ -78,7 +78,7 @@ Determines if the config provider supports polling the upstream secret stores fo
 * Valid Values:
 * Importance: MEDIUM
 
-```java
+```properties
 polling.interval.seconds
 ```
 The number of seconds to wait between polling intervals.
@@ -88,7 +88,7 @@ The number of seconds to wait between polling intervals.
 * Valid Values:
 * Importance: MEDIUM
 
-```java
+```properties
 vault.address
 ```
 Sets the address (URL) of the Vault server instance to which API calls should be sent. If no address is explicitly set, the object will look to the `VAULT_ADDR` If you do not supply it explicitly AND no environment variable value is found, then initialization may fail.
@@ -98,7 +98,7 @@ Sets the address (URL) of the Vault server instance to which API calls should be
 * Valid Values:
 * Importance: HIGH
 
-```java
+```properties
 vault.auth.method
 ```
 The login method to use. `AppRole` - Authentication via the `ldap
@@ -113,7 +113,7 @@ The login method to use. `AppRole` - Authentication via the `ldap
 * Valid Values: Matches: ``Token, LDAP, UserPass, Certificate, AppRole``
 * Importance: HIGH
 
-```java
+```properties
 vault.auth.mount
 ```
 Location of the mount to use for authentication.
@@ -123,7 +123,7 @@ Location of the mount to use for authentication.
 * Valid Values:
 * Importance: HIGH
 
-```java
+```properties
 vault.auth.password
 ```
 The password to authenticate with.
@@ -133,7 +133,7 @@ The password to authenticate with.
 * Valid Values:
 * Importance: HIGH
 
-```java
+```properties
 vault.auth.role
 ```
 The role to use for authentication.
@@ -143,7 +143,7 @@ The role to use for authentication.
 * Valid Values:
 * Importance: HIGH
 
-```java
+```properties
 vault.auth.secret
 ```
 The secret to use for authentication.
@@ -153,7 +153,7 @@ The secret to use for authentication.
 * Valid Values:
 * Importance: HIGH
 
-```java
+```properties
 vault.auth.token
 ```
 Sets the token used to access Vault. If no token is explicitly set then the `VAULT_TOKEN` environment variable will be used.
@@ -163,7 +163,7 @@ Sets the token used to access Vault. If no token is explicitly set then the `VAU
 * Valid Values:
 * Importance: HIGH
 
-```java
+```properties
 vault.auth.username
 ```
 The username to authenticate with.
@@ -173,7 +173,37 @@ The username to authenticate with.
 * Valid Values:
 * Importance: HIGH
 
-```java
+```properties
+vault.url.logging.enabled
+```
+Flag to copy java.util.logging messages for "sun.net.www.protocol.http.HttpURLConnection" to the providers logger. Warning this will log all of the traffic for ANY Vault client that is in the current JVM. This could also receive any log message for other code that uses java.net.UrlConnection.
+
+* Type: BOOLEAN
+* Default: false
+* Valid Values:
+* Importance: LOW
+
+```properties
+vault.prefixpath
+```
+Path prefix of the secret. Used to compute the path depth at which "/data" is inserted for kv v2 secrets. A placeholder may be used as only its depth is considered.
+
+* Type: STRING
+* Default:
+* Valid Values:
+* Importance: MEDIUM
+
+```properties
+vault.secrets.version
+```
+The secrets engine version (1 or 2) to use.
+
+* Type: INT
+* Default: 2
+* Valid Values:
+* Importance: MEDIUM
+
+```properties
 vault.ssl.verify.enabled
 ```
 Flag to determine if the configProvider should verify the SSL Certificate of the Vault server. Outside of development this should never be enabled.
@@ -189,17 +219,19 @@ Flag to determine if the configProvider should verify the SSL Certificate of the
 
 The following example uses a ldap username and password to authenticate to vault.
 
-```java
+```properties
 config.providers=vault
 config.providers.vault.class=io.confluent.csid.config.provider.vault.VaultConfigProvider
 config.providers.vault.param.vault.token=sdifgnabdifgasbffvasdfasdfadf
 config.providers.vault.param.vault.address=https://vault.example.com
 config.providers.vault.param.vault.auth.method=LDAP
 ```
+
 #### Token
+
 The following example uses a token to authenticate to vault.
 
-```java
+```properties
 config.providers=vault
 config.providers.vault.class=io.confluent.csid.config.provider.vault.VaultConfigProvider
 config.providers.vault.param.vault.token=sdifgnabdifgasbffvasdfasdfadf
@@ -208,9 +240,10 @@ config.providers.vault.param.vault.auth.method=Token
 ```
 
 #### Token, using kv store Version 1
+
 The following example uses a token to authenticate to vault.
 
-```java
+```properties
 config.providers=vault
 config.providers.vault.class=io.confluent.csid.config.provider.vault.VaultConfigProvider
 config.providers.vault.param.vault.token=sdifgnabdifgasbffvasdfasdfadf

--- a/vault/README.md
+++ b/vault/README.md
@@ -4,15 +4,13 @@
 confluent-hub install confluentinc/kafka-config-provider-vault:latest
 ```
 
-This plugin provides integration with Hashicorp Vault.
+This plugin provides integration with [Hashicorp Vault](https://www.hashicorp.com/products/vault/secrets-management).
 
 ## VaultConfigProvider
 
 This config provider is used to retrieve secrets from the Hashicorp Vault.
 
-
 ### Configuration
-
 
 #### General
 
@@ -23,7 +21,7 @@ The number of attempts to retrieve a secret from the upstream secret store.
 
 * Type: INT
 * Default: 3
-* Valid Values: 
+* Valid Values:
 * Importance: LOW
 
 ```properties
@@ -33,7 +31,7 @@ The amount of time in seconds to wait between each attempt to retrieve a secret 
 
 * Type: LONG
 * Default: 10
-* Valid Values: 
+* Valid Values:
 * Importance: LOW
 
 ```properties
@@ -43,7 +41,7 @@ The number of threads to use when retrieving secrets and executing subscription 
 
 * Type: INT
 * Default: 3
-* Valid Values: 
+* Valid Values:
 * Importance: LOW
 
 ```properties
@@ -53,7 +51,7 @@ The amount of time in seconds to wait before timing out a call to retrieve a sec
 
 * Type: LONG
 * Default: 30
-* Valid Values: 
+* Valid Values:
 * Importance: LOW
 
 ```properties
@@ -62,8 +60,8 @@ vault.namespace
 Sets a global namespace to the Vault server instance, if desired.
 
 * Type: STRING
-* Default: 
-* Valid Values: 
+* Default:
+* Valid Values:
 * Importance: LOW
 
 ```properties
@@ -73,7 +71,7 @@ Determines if the config provider supports polling the upstream secret stores fo
 
 * Type: BOOLEAN
 * Default: true
-* Valid Values: 
+* Valid Values:
 * Importance: MEDIUM
 
 ```properties
@@ -83,7 +81,7 @@ The number of seconds to wait between polling intervals.
 
 * Type: LONG
 * Default: 300
-* Valid Values: 
+* Valid Values:
 * Importance: MEDIUM
 
 ```properties
@@ -92,8 +90,8 @@ vault.address
 Sets the address (URL) of the Vault server instance to which API calls should be sent. If no address is explicitly set, the object will look to the `VAULT_ADDR` If you do not supply it explicitly AND no environment variable value is found, then initialization may fail.
 
 * Type: STRING
-* Default: 
-* Valid Values: 
+* Default:
+* Valid Values:
 * Importance: HIGH
 
 ```properties
@@ -117,8 +115,8 @@ vault.auth.mount
 Location of the mount to use for authentication.
 
 * Type: STRING
-* Default: 
-* Valid Values: 
+* Default:
+* Valid Values:
 * Importance: HIGH
 
 ```properties
@@ -128,7 +126,7 @@ The password to authenticate with.
 
 * Type: PASSWORD
 * Default: [hidden]
-* Valid Values: 
+* Valid Values:
 * Importance: HIGH
 
 ```properties
@@ -137,8 +135,8 @@ vault.auth.role
 The role to use for authentication.
 
 * Type: STRING
-* Default: 
-* Valid Values: 
+* Default:
+* Valid Values:
 * Importance: HIGH
 
 ```properties
@@ -148,17 +146,17 @@ The secret to use for authentication.
 
 * Type: PASSWORD
 * Default: [hidden]
-* Valid Values: 
+* Valid Values:
 * Importance: HIGH
 
 ```properties
 vault.auth.token
 ```
-Sets the token used to access Vault. If no token is explicitly set then the `VAULT_TOKEN` environment variable will be used. 
+Sets the token used to access Vault. If no token is explicitly set then the `VAULT_TOKEN` environment variable will be used.
 
 * Type: PASSWORD
 * Default: [hidden]
-* Valid Values: 
+* Valid Values:
 * Importance: HIGH
 
 ```properties
@@ -167,8 +165,8 @@ vault.auth.username
 The username to authenticate with.
 
 * Type: STRING
-* Default: 
-* Valid Values: 
+* Default:
+* Valid Values:
 * Importance: HIGH
 
 ```properties
@@ -178,17 +176,17 @@ Flag to copy java.util.logging messages for "sun.net.www.protocol.http.HttpURLCo
 
 * Type: BOOLEAN
 * Default: false
-* Valid Values: 
+* Valid Values:
 * Importance: LOW
 
 ```properties
 vault.prefixpath
 ```
-Path prefix for the secrets.
+Path prefix of the secret. Used to compute the path depth at which "/data" is inserted for kv v2 secrets. A placeholder may be used as only its depth is considered.
 
 * Type: STRING
-* Default: 
-* Valid Values: 
+* Default:
+* Valid Values:
 * Importance: MEDIUM
 
 ```properties
@@ -198,7 +196,7 @@ The secrets engine version (1 or 2) to use.
 
 * Type: INT
 * Default: 2
-* Valid Values: 
+* Valid Values:
 * Importance: MEDIUM
 
 ```properties
@@ -208,7 +206,7 @@ Flag to determine if the configProvider should verify the SSL Certificate of the
 
 * Type: BOOLEAN
 * Default: true
-* Valid Values: 
+* Valid Values:
 * Importance: HIGH
 
 ### Examples
@@ -222,7 +220,7 @@ config.providers=vault
 config.providers.vault.class=io.confluent.csid.config.provider.vault.VaultConfigProvider
 config.providers.vault.param.vault.token=sdifgnabdifgasbffvasdfasdfadf
 config.providers.vault.param.vault.address=https://vault.example.com
-config.providers.vault.param.vault.login.by=LDAP
+config.providers.vault.param.vault.auth.method=LDAP
 ```
 
 #### Token
@@ -234,7 +232,18 @@ config.providers=vault
 config.providers.vault.class=io.confluent.csid.config.provider.vault.VaultConfigProvider
 config.providers.vault.param.vault.token=sdifgnabdifgasbffvasdfasdfadf
 config.providers.vault.param.vault.address=https://vault.example.com
-config.providers.vault.param.vault.login.by=Token
+config.providers.vault.param.vault.auth.method=Token
 ```
 
+#### Token, using kv store Version 1
 
+The following example uses a token to authenticate to vault.
+
+```properties
+config.providers=vault
+config.providers.vault.class=io.confluent.csid.config.provider.vault.VaultConfigProvider
+config.providers.vault.param.vault.token=sdifgnabdifgasbffvasdfasdfadf
+config.providers.vault.param.vault.address=https://vault.example.com
+config.providers.vault.param.vault.auth.method=Token
+config.providers.vault.param.secrets.version=1
+```


### PR DESCRIPTION

## Description

Previously unclear vault.prefixpath parameter as it is not inserted as the actual prefix.
Align the documentation of hashicorp vault README and Github page.

## Motivation and Context

Clearer documentation.

## How Has This Been Tested?

Markdown preview

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.