### PR TITLE
Fix SecretManager implementation to support AwsSessionCredentials refresh

### DIFF
--- a/aws/src/main/java/io/confluent/csid/config/provider/aws/SecretsManagerFactoryImpl.java
+++ b/aws/src/main/java/io/confluent/csid/config/provider/aws/SecretsManagerFactoryImpl.java
@@ -117,6 +117,7 @@
  */
 package io.confluent.csid.config.provider.aws;
 
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
@@ -150,10 +151,10 @@ class SecretsManagerFactoryImpl implements SecretsManagerFactory {
     if (null != config.endpointOverride && !config.endpointOverride.isEmpty()) {
       builder = builder.endpointOverride(URI.create(config.endpointOverride));
     }
-    if (null != config.credentials) {
+    if (config.credentials instanceof AwsBasicCredentials) {
       builder = builder.credentialsProvider(StaticCredentialsProvider.create(config.credentials));
     } else {
-      defaultCredentialsProvider = DefaultCredentialsProvider.create();
+      defaultCredentialsProvider = DefaultCredentialsProvider.builder().asyncCredentialUpdateEnabled(true).build();
       builder = builder.credentialsProvider(defaultCredentialsProvider);
     }
     return builder;


### PR DESCRIPTION
Fix SecretManager implementation to support AwsSessionCredentials refresh

## Description
Check that config.credentials is AwsBasicCredentials before creating a StaticCredentialsProvider.
Enable aws sdk asyncCredentialsUpdate in order for the SDK to asynchronously update the credentials

## Motivation and Context
Before this change, SecretManager was created with StaticCredentialsProvider. This caused problem when using ContainerCredentialsProvider from the DefaultCredentialsProvider chain because this returns AWSSessionCredentials that are expiring. Running on ECS, this would cause the plugin to stop working 6 hours after the task being launched because the static credentials becomes invalid.

## How Has This Been Tested?
Built csid-secrets-provider with the change and added him to our Kafka Connector plugins folder.
Saved configuration immediatly using a secret, observed that it worked.
Saved configuration more than 6 hours after launching the task, observed that it worked.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.