### PR TITLE
[DP-15772] cleanup Semaphore pipeline

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -25,14 +25,7 @@ blocks:
         commands:
           - sem-version java 17
           - checkout
-          - make install-vault
-          - . mk-include/bin/vault-setup
-          - . vault-sem-get-secret semaphore-secrets-global
-          - . vault-sem-get-secret aws_credentials
-          - . vault-sem-get-secret dockerhub-semaphore-cred-ro
-          - . vault-sem-get-secret netrc
-          - . vault-sem-get-secret ssh_config
-          - . vault-sem-get-secret maven-settings
+          - . vault-setup
           - make docker-login-ci
       jobs:
         - name: Build without Tests


### PR DESCRIPTION
## Background
This PR brings the pipeline up to the latest standards by:
* removing unnecessary commands and secrets - They are set automatically on the Semaphore agents.
* replacing deprecated commands and secrets with active ones - The deprecated secrets will be deleted.
* updating the Python version to 3.11 (if necessary) - The previous version is EOL and no longer installed on Semaphore agents. This will speed up the pipeline.

If this PR is not merged, the pipeline may begin to fail due to the removal of deprecated commands and secrets or incompatibility.

## Actions
Please approve and merge this change. If status checks are failing, please debug as necessary.
