### PR TITLE
Vault - Incorrect parameter for auth.token in Vault Config Provider examples #335

### DIFF
--- a/vault/README.md
+++ b/vault/README.md
@@ -218,7 +218,7 @@ The following example uses a ldap username and password to authenticate to vault
 ```properties
 config.providers=vault
 config.providers.vault.class=io.confluent.csid.config.provider.vault.VaultConfigProvider
-config.providers.vault.param.vault.token=sdifgnabdifgasbffvasdfasdfadf
+config.providers.vault.param.vault.auth.token=sdifgnabdifgasbffvasdfasdfadf
 config.providers.vault.param.vault.address=https://vault.example.com
 config.providers.vault.param.vault.auth.method=LDAP
 ```
@@ -230,7 +230,7 @@ The following example uses a token to authenticate to vault.
 ```properties
 config.providers=vault
 config.providers.vault.class=io.confluent.csid.config.provider.vault.VaultConfigProvider
-config.providers.vault.param.vault.token=sdifgnabdifgasbffvasdfasdfadf
+config.providers.vault.param.vault.auth.token=sdifgnabdifgasbffvasdfasdfadf
 config.providers.vault.param.vault.address=https://vault.example.com
 config.providers.vault.param.vault.auth.method=Token
 ```
@@ -242,7 +242,7 @@ The following example uses a token to authenticate to vault.
 ```properties
 config.providers=vault
 config.providers.vault.class=io.confluent.csid.config.provider.vault.VaultConfigProvider
-config.providers.vault.param.vault.token=sdifgnabdifgasbffvasdfasdfadf
+config.providers.vault.param.vault.auth.token=sdifgnabdifgasbffvasdfasdfadf
 config.providers.vault.param.vault.address=https://vault.example.com
 config.providers.vault.param.vault.auth.method=Token
 config.providers.vault.param.secrets.version=1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The README of the Vault Config Provider had a mistake in the properties example.

## Description
<!--- Describe your changes in detail -->
The property for defining the Token used for authentication with Vault was missing `.auth`.
This was going to be a minor PR, but I noticed that there is an issue about this already.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Issue has been created in the past already: https://github.com/confluentinc/csid-secrets-providers/issues/335

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally via Docker.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.