### PR TITLE
Schedule token renewal based on ttl

### DIFF
--- a/vault/src/main/java/io/confluent/csid/config/provider/vault/VaultClientImpl.java
+++ b/vault/src/main/java/io/confluent/csid/config/provider/vault/VaultClientImpl.java
@@ -148,7 +148,7 @@ class VaultClientImpl implements VaultClient {
     if (result.ttl().isPresent() && result.ttl().get() > 0) {
       log.debug("ctor() - AuthResult does have a ttl - scheduling token renewal.");
       executorService.scheduleAtFixedRate(() -> authenticateVault(config, vaultConfig),
-              0, result.ttl().get(), TimeUnit.SECONDS);
+              0, result.ttl().get() - ( result.ttl().get() / 10 ), TimeUnit.SECONDS);
     } else {
       log.debug("ctor() - AuthResult does not have a ttl so not scheduling token refresh.");
     }

--- a/vault/src/main/java/io/confluent/csid/config/provider/vault/VaultClientImpl.java
+++ b/vault/src/main/java/io/confluent/csid/config/provider/vault/VaultClientImpl.java
@@ -148,7 +148,7 @@ class VaultClientImpl implements VaultClient {
     if (result.ttl().isPresent() && result.ttl().get() > 0) {
       log.debug("ctor() - AuthResult does have a ttl - scheduling token renewal.");
       executorService.scheduleAtFixedRate(() -> authenticateVault(config, vaultConfig),
-              0, result.ttl().get() - ( result.ttl().get() / 10 ), TimeUnit.SECONDS);
+              0, result.ttl().get() - (result.ttl().get() / 10), TimeUnit.SECONDS);
     } else {
       log.debug("ctor() - AuthResult does not have a ttl so not scheduling token refresh.");
     }

--- a/vault/src/main/java/io/confluent/csid/config/provider/vault/VaultClientImpl.java
+++ b/vault/src/main/java/io/confluent/csid/config/provider/vault/VaultClientImpl.java
@@ -127,28 +127,39 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 class VaultClientImpl implements VaultClient {
   private static final Logger log = LoggerFactory.getLogger(VaultClientImpl.class);
   final AtomicReference<Vault> vaultStore = new AtomicReference<>();
   final AtomicReference<AuthHandler.AuthResult> authResultStore = new AtomicReference<>();
-  final VaultConfigProviderConfig config;
-  final ScheduledExecutorService executorService;
 
 
   public VaultClientImpl(VaultConfigProviderConfig config, ScheduledExecutorService executorService) {
-    this.config = config;
-    this.executorService = executorService;
 
     VaultConfig vaultConfig = config.createConfig();
     log.info("ctor() - creating initial vault client");
 
-    AuthHandler authHandler = AuthHandlers.get(config.authMethod);
     Vault initialVault = Vault.create(vaultConfig);
+    this.vaultStore.set(initialVault);
+    AuthHandler.AuthResult result = authenticateVault(config, vaultConfig);
+
+    if (result.ttl().isPresent() && result.ttl().get() > 0) {
+      log.debug("ctor() - AuthResult does have a ttl - scheduling token renewal.");
+      executorService.scheduleAtFixedRate(() -> authenticateVault(config, vaultConfig),
+              0, result.ttl().get(), TimeUnit.SECONDS);
+    } else {
+      log.debug("ctor() - AuthResult does not have a ttl so not scheduling token refresh.");
+    }
+  }
+
+  private AuthHandler.AuthResult authenticateVault(VaultConfigProviderConfig config, VaultConfig vaultConfig) {
+    log.debug("ctor() - authenticating vault");
+    AuthHandler authHandler = AuthHandlers.get(config.authMethod);
     AuthHandler.AuthResult result;
     try {
-      result = authHandler.execute(config, initialVault);
+      result = authHandler.execute(config, this.vaultStore.get());
     } catch (VaultException exception) {
       log.error("ctor() - exception thrown during initial authentication", exception);
       ConfigException configException = new ConfigException("Exception during initial authentication");
@@ -157,28 +168,7 @@ class VaultClientImpl implements VaultClient {
     }
     log.debug("ctor() - authResult = {}", result);
     result.token().ifPresent(vaultConfig::token);
-    this.vaultStore.set(initialVault);
-
-    if (result.ttl().isPresent() && result.ttl().get() > 0) {
-      log.debug("ctor() - AuthResult does have a ttl - ignoring.");
-    } else {
-      log.debug("ctor() - AuthResult does not have a ttl so not scheduling token refresh.");
-    }
-  }
-
-  class TokenRenewer implements Runnable {
-    @Override
-    public void run() {
-
-    }
-  }
-
-  static class AuthRokenRenewer implements Runnable {
-
-    @Override
-    public void run() {
-
-    }
+    return result;
   }
 
 


### PR DESCRIPTION
Vault token does not get renewed once it reaches it's ttl. 

## Description
The token needs to be renewed once it reaches the ttl. The VaultClientImpl has the template (background thread) to implement this but missing the implementation. I have created a scheduled task to reauthenticate vault and set the renewed token.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We use the VaultConfigProvider in the connect cluster to retrieve secrets from vault. We use AppRole base authentication. The generated token has ttl of 60 mins. Connectors deployed in the first 60 mins are able to retrieve secrets from vault. After 60 mins have passed connectors cannot be deployed due to being unable to retrieve secrets from vault with an expired token.
As a workaround we are forced to redeploy/restart the connect cluster so that the token gets renewed.
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/confluentinc/csid-secrets-providers/issues/325

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Deployed the connect cluster with a snapshot version of the fixed library. Added debug logs before and after the vault authentication code block. Checked for logs to see if the authentication is triggered every 60 mis. 
Tried installing connectors after 60 mins have passed.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.