### PR TITLE
gcloud-secret-dependency-update

### DIFF
--- a/gcloud/pom.xml
+++ b/gcloud/pom.xml
@@ -172,6 +172,10 @@
             <groupId>io.confluent.csid</groupId>
             <artifactId>csid-secrets-provider-annotations</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-rls</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
[Include grpc-rls to fix issue for CP 7.9] 

## Description
 there is a dependency conflict between kafka classes , metadata dir and this converter classes. Similar issues was faced by many confluent gcp connectors were this dependency grpc-rls solved the issue. 
Reference [(https://github.com/confluentinc/kafka-connect-gcp-pubsub/pull/115)]


## Motivation and Context
Error:

```
2025-05-09 08:09:14,898] INFO Loading credentials file '/var/ssl/private/gcpcred.json' (io.confluent.csid.config.provider.gcloud.SecretManagerConfigProviderConfig:226)
[2025-05-09 08:09:15,176] ERROR Stopping due to error (org.apache.kafka.connect.cli.AbstractConnectCli:109)
java.util.ServiceConfigurationError: io.grpc.LoadBalancerProvider: io.grpc.rls.RlsLoadBalancerProvider not a subtype
        at java.base/java.util.ServiceLoader.fail(ServiceLoader.java:593)
        at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNextService(ServiceLoader.java:1244)
        at java.base/java.util.ServiceLoader$LazyClassPathLookupIterator.hasNext(ServiceLoader.java:1273)
        at java.base/java.util.ServiceLoader$2.hasNext(ServiceLoader.java:1309)
        at java.base/java.util.ServiceLoader$3.hasNext(ServiceLoader.java:1393)
        at io.grpc.ServiceProviders.loadAll(ServiceProviders.java:67)
        at io.grpc.LoadBalancerRegistry.getDefaultRegistry(LoadBalancerRegistry.java:102)
        at io.grpc.internal.AutoConfiguredLoadBalancerFactory.<init>(AutoConfiguredLoadBalancerFactory.java:51)
        at io.grpc.internal.ManagedChannelImpl.<init>(ManagedChannelImpl.java:581)
        at io.grpc.internal.ManagedChannelImplBuilder.build(ManagedChannelImplBuilder.java:710)
        at io.grpc.ForwardingChannelBuilder2.build(ForwardingChannelBuilder2.java:272)
        at com.google.api.gax.grpc.InstantiatingGrpcChannelProvider.createSingleChannel(InstantiatingGrpcChannelProvider.java:497)
        at com.google.api.gax.grpc.ChannelPool.<init>(ChannelPool.java:106)
        at com.google.api.gax.grpc.ChannelPool.create(ChannelPool.java:84)
        at com.google.api.gax.grpc.InstantiatingGrpcChannelProvider.createChannel(InstantiatingGrpcChannelProvider.java:267)
        at com.google.api.gax.grpc.InstantiatingGrpcChannelProvider.getTransportChannel(InstantiatingGrpcChannelProvider.java:260)
        at com.google.api.gax.rpc.ClientContext.create(ClientContext.java:225)
        at com.google.cloud.secretmanager.v1.stub.GrpcSecretManagerServiceStub.create(GrpcSecretManagerServiceStub.java:248)
        at com.google.cloud.secretmanager.v1.stub.SecretManagerServiceStubSettings.createStub(SecretManagerServiceStubSettings.java:359)
        at com.google.cloud.secretmanager.v1.SecretManagerServiceClient.<init>(SecretManagerServiceClient.java:455)
        at com.google.cloud.secretmanager.v1.SecretManagerServiceClient.create(SecretManagerServiceClient.java:437)
        at io.confluent.csid.config.provider.gcloud.SecretManagerFactoryImpl.create(SecretManagerFactoryImpl.java:133)
        at io.confluent.csid.config.provider.gcloud.SecretManagerConfigProvider.configure(SecretManagerConfigProvider.java:181)
        at io.confluent.csid.config.provider.common.AbstractConfigProvider.configure(AbstractConfigProvider.java:202)
        at org.apache.kafka.common.config.AbstractConfig.instantiateConfigProviders(AbstractConfig.java:627)
        at org.apache.kafka.common.config.AbstractConfig.resolveConfigVariables(AbstractConfig.java:547)
        at org.apache.kafka.common.config.AbstractConfig.<init>(AbstractConfig.java:116)
        at org.apache.kafka.connect.runtime.WorkerConfig.<init>(WorkerConfig.java:572)
        at org.apache.kafka.connect.runtime.distributed.DistributedConfig.<init>(DistributedConfig.java:697)
        at org.apache.kafka.connect.runtime.distributed.DistributedConfig.<init>(DistributedConfig.java:691)
        at org.apache.kafka.connect.cli.ConnectDistributed.createConfig(ConnectDistributed.java:107)
        at org.apache.kafka.connect.cli.ConnectDistributed.createConfig(ConnectDistributed.java:54)
        at org.apache.kafka.connect.cli.AbstractConnectCli.startConnect(AbstractConnectCli.java:133)
        at org.apache.kafka.connect.cli.AbstractConnectCli.run(AbstractConnectCli.java:102)
        at org.apache.kafka.connect.cli.ConnectDistributed.main(ConnectDistributed.java:112)

```
## How Has This Been Tested?
Manually tested by adding the dependency followed by maven code build and running kafka connect node with latest package.

## Screenshots (if appropriate):

Verified this converter runs as expected after adding these configuration in kafka connect node.

config.providers = gcp
config.providers.gcp.class = io.confluent.csid.config.provider.gcloud.SecretManagerConfigProvider
config.providers.gcp.param.credential.location=File
config.providers.gcp.param.credential.file=/var/ssl/private/gcpcred.json
config.providers.gcp.param.project.id=123456
config.providers.gcp.param.retry.count=3
config.providers.gcp.param.retry.interval.seconds=10
config.providers.gcp.param.timeout.seconds=30
config.providers.gcp.param.polling.enabled=true
config.providers.gcp.param.polling.interval.seconds=300
config.providers.gcp.param.use.json = true

## Types of changes
- [x] Bug fix 

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.