### PR TITLE
Make ProviderConfig classes public

### DIFF
--- a/aws/src/main/java/io/confluent/csid/config/provider/aws/SecretsManagerConfigProviderConfig.java
+++ b/aws/src/main/java/io/confluent/csid/config/provider/aws/SecretsManagerConfigProviderConfig.java
@@ -127,7 +127,7 @@ import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import java.time.Duration;
 import java.util.Map;
 
-class SecretsManagerConfigProviderConfig extends AbstractConfigProviderConfig {
+public class SecretsManagerConfigProviderConfig extends AbstractConfigProviderConfig {
   public static final String REGION_CONFIG = "aws.region";
   static final String REGION_DOC = "Sets the region to be used by the client. For example `us-west-2`";
 

--- a/azure/src/main/java/io/confluent/csid/config/provider/azure/KeyVaultConfigProviderConfig.java
+++ b/azure/src/main/java/io/confluent/csid/config/provider/azure/KeyVaultConfigProviderConfig.java
@@ -138,7 +138,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
-class KeyVaultConfigProviderConfig extends AbstractConfigProviderConfig {
+public class KeyVaultConfigProviderConfig extends AbstractConfigProviderConfig {
   private static final Logger log = LoggerFactory.getLogger(KeyVaultConfigProviderConfig.class);
   public static final String PREFIX_CONFIG = "secret.prefix";
   static final String PREFIX_DOC = "Sets a prefix that will be added to all paths. For example you can use `staging` or `production` " +

--- a/gcloud/src/main/java/io/confluent/csid/config/provider/gcloud/SecretManagerConfigProviderConfig.java
+++ b/gcloud/src/main/java/io/confluent/csid/config/provider/gcloud/SecretManagerConfigProviderConfig.java
@@ -135,7 +135,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
-class SecretManagerConfigProviderConfig extends AbstractConfigProviderConfig {
+public class SecretManagerConfigProviderConfig extends AbstractConfigProviderConfig {
   private static final Logger log = LoggerFactory.getLogger(SecretManagerConfigProviderConfig.class);
 
   public static final String CREDENTIAL_LOCATION_CONFIG = "credential.location";

--- a/k8s/src/main/java/io/confluent/csid/config/provider/k8s/K8sSecretConfigProviderConfig.java
+++ b/k8s/src/main/java/io/confluent/csid/config/provider/k8s/K8sSecretConfigProviderConfig.java
@@ -122,7 +122,7 @@ import org.apache.kafka.common.config.ConfigDef;
 
 import java.util.Map;
 
-class K8sSecretConfigProviderConfig extends AbstractConfigProviderConfig {
+public class K8sSecretConfigProviderConfig extends AbstractConfigProviderConfig {
   public K8sSecretConfigProviderConfig(Map<String, ?> settings) {
     super(config(), settings);
   }

--- a/vault/src/main/java/io/confluent/csid/config/provider/vault/VaultConfigProviderConfig.java
+++ b/vault/src/main/java/io/confluent/csid/config/provider/vault/VaultConfigProviderConfig.java
@@ -136,7 +136,7 @@ import java.util.logging.Level;
 import static io.confluent.csid.config.provider.common.config.ConfigUtils.getEnum;
 import static io.confluent.csid.config.provider.common.util.Utils.isNullOrEmpty;
 
-class VaultConfigProviderConfig extends AbstractConfigProviderConfig {
+public class VaultConfigProviderConfig extends AbstractConfigProviderConfig {
   public static final String ADDRESS_CONFIG = "vault.address";
   static final String ADDRESS_DOC = "Sets the address (URL) of the Vault server instance to which API calls should be sent. " +
       "If no address is explicitly set, the object will look to the `VAULT_ADDR` If you do not supply it explicitly AND no " +


### PR DESCRIPTION
We are planning to use csid-secrets-providers repo to integrate 3rd party store support in gateway filters.

In order to map gateway filter configs to csid compatible configs, we need to create the config map based on what csid-secrets-providers understand.

For that, we need access to the config classes (aka make them public) from csid-secrets-providers