### PR TITLE
chore(release): publish artifacts to maven central

### DIFF
--- a/.semaphore/initgpg.sh
+++ b/.semaphore/initgpg.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Copyright (C) 2020-2025 Confluent, Inc.
+#
+
+set -o errexit -o nounset -o pipefail
+echo -e "${PRIVATE_KEY}" | gpg --import --batch --no-tty
+cat <<GPG_AGENT_CFG > ~/.gnupg/gpg-agent.conf
+use-agent
+pinentry-mode loopback
+allow-preset-passphrase
+GPG_AGENT_CFG
+
+gpg-connect-agent reloadagent /bye
+KEY_GRIP=$(gpg --with-keygrip -K --with-colons | grep '^grp' | head -1 | cut -d: -f10)
+"$(gpgconf --list-dirs libexecdir)"/gpg-preset-passphrase --preset "${KEY_GRIP}" <<< "${PASSPHRASE}"
+
+gpg --with-keygrip -k --with-colons | grep '^fpr' | head -1 | cut -d: -f10 > keygrip.txt
+echo "Determined KEY_ID: $(cat keygrip.txt)"
+rm -f keygrip.txt

--- a/.semaphore/publish_to_mavencentral.yml
+++ b/.semaphore/publish_to_mavencentral.yml
@@ -1,0 +1,45 @@
+#
+# Copyright (C) 2021-2025 Confluent, Inc.
+#
+
+version: v1.0
+name: Publish to Maven Central
+agent:
+  machine:
+    type: s1-prod-ubuntu24-04-amd64-1
+
+global_job_config:
+  prologue:
+    commands:
+      - sem-version java 17
+
+blocks:
+  - name: Deploy to Maven Central
+    task:
+      jobs:
+        - name: Publish Artifacts
+          commands:
+            - |
+              if [[ "${SEMAPHORE_ORGANIZATION_URL}" == *".semaphoreci.com" ]]; then
+                echo "Not meant to run on public semaphore!"
+                exit 1
+              fi
+            - checkout
+            - git fetch --unshallow
+            - . vault-setup
+            - . vault-sem-get-secret v1/ci/kv/semaphore2/gpg/confluent-packaging-private-8B1DA6120C2BF624
+            - chmod +x .semaphore/initgpg.sh
+            - . .semaphore/initgpg.sh
+            - export SONATYPE_SERVER_ID=ossrh
+            - export SONATYPE_OSSRH_USER=$(vault kv get --field=user_token_username v1/ci/kv/sonatype/confluent)
+            - export SONATYPE_OSSRH_PASSWORD=$(vault kv get --field=user_token_password v1/ci/kv/sonatype/confluent)
+            - export SETTINGS_XML_PATH="$HOME/.m2/settings.xml"
+            - python .semaphore/update_maven_settings.py # Update maven settings with Sonatype credentials
+            - ./mvnw --batch-mode clean deploy -Ppublish-to-central -Dgpg.passphrase=$PASSPHRASE -DskipTests
+
+after_pipeline:
+  task:
+    jobs:
+      - name: Publish Results
+        commands:
+          - test-results gen-pipeline-report

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -42,3 +42,5 @@ after_pipeline:
 promotions:
   - name: Publish to Codeartifact
     pipeline_file: publish_to_codeartifact.yml
+  - name : Publish to Maven Central
+    pipeline_file : publish_to_mavencentral.yml

--- a/.semaphore/update_maven_settings.py
+++ b/.semaphore/update_maven_settings.py
@@ -1,0 +1,67 @@
+import os
+import xml.etree.ElementTree as ET
+import xml.dom.minidom
+
+
+def get_environment_variables():
+    username = os.getenv("SONATYPE_OSSRH_USER")
+    password = os.getenv("SONATYPE_OSSRH_PASSWORD")
+    server_id = os.getenv("SONATYPE_SERVER_ID")
+    settings_xml_path = os.getenv("SETTINGS_XML_PATH")
+
+    if not (username and password and server_id and settings_xml_path):
+        print("Error: One or more environment variables are not set.")
+        exit(1)
+
+    return username, password, server_id, settings_xml_path
+
+
+def find_or_create_servers_element(root):
+    namespace_uri = "http://maven.apache.org/SETTINGS/1.0.0"
+    ET.register_namespace("", namespace_uri)
+    namespace = {'maven': namespace_uri}
+    servers = root.find(".//maven:servers", namespaces=namespace)
+    if servers is None:
+        servers = ET.SubElement(root, "servers")
+    return servers
+
+
+def check_server_existence(servers, server_id):
+    namespace = {'maven': 'http://maven.apache.org/SETTINGS/1.0.0'}
+    existing_server_ids = [server.find("maven:id", namespaces=namespace).text for server in
+                           servers.findall("maven:server", namespaces=namespace)]
+    return server_id in existing_server_ids
+
+
+def add_server_element(servers, server_id, username, password):
+    new_server = ET.SubElement(servers, "server")
+    id_elem = ET.SubElement(new_server, "id")
+    id_elem.text = server_id
+    username_elem = ET.SubElement(new_server, "username")
+    username_elem.text = username
+    password_elem = ET.SubElement(new_server, "password")
+    password_elem.text = password
+    print(f"Added server with ID '{server_id}' to settings.xml.")
+
+
+def write_settings_xml(tree, settings_xml_path):
+    tree_str = ET.tostring(tree.getroot(), encoding="utf-8", method="xml")
+    xml_str = xml.dom.minidom.parseString(tree_str)
+    with open(settings_xml_path, "w", encoding="utf-8") as f:
+        f.write(xml_str.toprettyxml(newl=""))
+
+
+def main():
+    username, password, server_id, settings_xml_path = get_environment_variables()
+    tree = ET.parse(settings_xml_path)
+    servers = find_or_create_servers_element(tree.getroot())
+    if check_server_existence(servers, server_id):
+        print(f"Server with ID '{server_id}' already exists. No updates are made")
+    else:
+        add_server_element(servers, server_id, username, password)
+        write_settings_xml(tree, settings_xml_path)
+        print("Updated settings.xml with server information.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,12 @@
   <artifactId>csid-secrets-providers</artifactId>
   <version>1.0.42-SNAPSHOT</version>
   <packaging>pom</packaging>
+  <description>Enables use of external third-party systems for storing/retrieving key/value pairs with Confluent clusters.</description>
+  <url>https://confluent.io</url>
+  <organization>
+    <name>Confluent, Inc.</name>
+    <url>https://confluent.io</url>
+  </organization>
   <properties>
     <license.path>${project.basedir}/LICENSE</license.path>
     <confluent.hub.packaging.version>0.12.0</confluent.hub.packaging.version>
@@ -188,6 +194,48 @@
           <url>s3://confluent-csid-maven/snapshots</url>
         </snapshotRepository>
       </distributionManagement>
+    </profile>
+    <profile>
+      <id>publish-to-central</id>
+      <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+      </distributionManagement>
+      <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.7.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
+        </plugins>
+      </build>
     </profile>
     <profile>
       <id>publish-to-codeartifact</id>

--- a/service.yml
+++ b/service.yml
@@ -12,3 +12,6 @@ semaphore:
     - name: Upload to Codeartifact
       branch: main
       pipeline_file: ".semaphore/secrets-providers/publish_to_codeartifact.yml"
+    - name: Publish to Maven Central
+      branch: main
+      pipeline_file: ".semaphore/publish_to_mavencentral.yml"


### PR DESCRIPTION
This pull request introduces the functionality to publish Maven artifacts to Maven Central, including the necessary configurations, scripts, and updates to the build process. The changes span multiple files and address the setup of GPG keys, Maven settings, and CI/CD pipelines.

### Maven Central Publishing Setup:

* **GPG Key Initialization Script**: Added `.semaphore/initgpg.sh` to configure GPG for signing artifacts, including importing private keys and setting up the GPG agent.

* **Maven Settings Update Script**: Added `.semaphore/update_maven_settings.py` to dynamically update Maven's `settings.xml` with Sonatype credentials for publishing.

* **Maven Central Profile in `pom.xml`**:
  - Added a `publish-to-central` profile to configure distribution management for Sonatype repositories and include plugins for artifact signing and staging.
  - Enhanced project metadata with a description, URL, and organization details.

### CI/CD Pipeline Configuration:

* **New Pipeline for Maven Central**:
  - Added `.semaphore/publish_to_mavencentral.yml` to define the pipeline for deploying artifacts to Maven Central, including steps for setting up GPG, updating Maven settings, and running the Maven deploy command.
  - Integrated the new pipeline into the main CI/CD workflow in `service.yml` and added a promotion step in `.semaphore/semaphore.yml`. [[1]](diffhunk://#diff-1b0a33dc9596b69675f6e7dd4cf444fd0efa6d205b966144f0118d990c13cd68R15-R17) [[2]](diffhunk://#diff-f4c421dab68fb568a2a5f47b7851a85a409574b05f841f635bad1880b82db03bR45-R46)