### PR TITLE
fix: Enhance pom.xml and Semaphore configurations

### DIFF
--- a/.semaphore/publish_to_codeartifact.yml
+++ b/.semaphore/publish_to_codeartifact.yml
@@ -8,25 +8,28 @@ agent:
   machine:
     type: s1-prod-ubuntu24-04-amd64-1
 
-global_job_config:
-  env_vars:
-    - name: MAVEN_OPTS
-      value: "-Dmaven.repo.local=.m2"
-  prologue:
-    commands:
-      - checkout
-      - sem-version java 17
-      - . vault-setup
-      - make docker-login-ci
-
 blocks:
   - name: Deploy to Codeartifact
     task:
+      env_vars:
+        - name: MAVEN_OPTS
+          value: "-Dmaven.repo.local=.m2"
+      prologue:
+        commands:
+          - sem-version java 17
+          - checkout
+          - . vault-setup
+          - make docker-login-ci
       jobs:
         - name: Publish Artifacts
           commands:
             - ./mvnw clean verify install dependency:analyze validate
-            - cache store
             # Download all JARs possible and compile as much as possible
             # Use -q to reduce output spam
             - ./mvnw -q -DskipTests -Ppublish-to-codeartifact deploy
+after_pipeline:
+  task:
+    jobs:
+      - name: Publish Results
+        commands:
+          - test-results gen-pipeline-report

--- a/.semaphore/publish_to_mavencentral.yml
+++ b/.semaphore/publish_to_mavencentral.yml
@@ -8,14 +8,15 @@ agent:
   machine:
     type: s1-prod-ubuntu24-04-amd64-1
 
-global_job_config:
-  prologue:
-    commands:
-      - sem-version java 17
-
 blocks:
   - name: Deploy to Maven Central
     task:
+      env_vars:
+        - name: MAVEN_OPTS
+          value: "-Dmaven.repo.local=.m2"
+      prologue:
+        commands:
+          - sem-version java 17
       jobs:
         - name: Publish Artifacts
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -31,7 +31,6 @@ blocks:
         - name: Build without Tests
           commands:
             - ./mvnw clean verify install dependency:analyze validate
-            - cache store
 after_pipeline:
   task:
     jobs:
@@ -42,5 +41,9 @@ after_pipeline:
 promotions:
   - name: Publish to Codeartifact
     pipeline_file: publish_to_codeartifact.yml
-  - name : Publish to Maven Central
-    pipeline_file : publish_to_mavencentral.yml
+    auto_promote:
+      when: "result = 'passed' and tag =~ '.*'"
+  - name: Publish to Maven Central
+    pipeline_file: publish_to_mavencentral.yml
+    auto_promote:
+      when: "result = 'passed' and tag =~ '.*'"

--- a/pom.xml
+++ b/pom.xml
@@ -124,12 +124,23 @@
   <artifactId>csid-secrets-providers</artifactId>
   <version>1.0.43-SNAPSHOT</version>
   <packaging>pom</packaging>
+  <name>Confluent CSID Secrets Providers</name>
   <description>Enables use of external third-party systems for storing/retrieving key/value pairs with Confluent clusters.</description>
   <url>https://confluent.io</url>
   <organization>
     <name>Confluent, Inc.</name>
     <url>https://confluent.io</url>
   </organization>
+  <developers>
+    <developer>
+      <id>csid</id>
+      <name>Accelerators</name>
+      <email>accelerators@confluent.io</email>
+      <organization>Confluent, Inc.</organization>
+      <organizationUrl>https://confluent.io</organizationUrl>
+      <timezone>America/Los_Angeles</timezone>
+    </developer>
+  </developers>
   <properties>
     <license.path>${project.basedir}/LICENSE</license.path>
     <confluent.hub.packaging.version>0.12.0</confluent.hub.packaging.version>
@@ -209,6 +220,36 @@
       </distributionManagement>
       <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.6.3</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <failOnError>false</failOnError>
+                    <failOnWarnings>false</failOnWarnings>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>


### PR DESCRIPTION
This pull request introduces changes to streamline CI/CD pipelines, improve artifact publishing workflows, and enhance metadata in the Maven `pom.xml` file. Key updates include restructuring Semaphore pipeline configurations, adding auto-promotion rules, and enriching project metadata for Maven Central publishing.

### CI/CD Pipeline Updates:
* [`.semaphore/publish_to_codeartifact.yml`](diffhunk://#diff-cb65905fe3ebc9e47288ba39078a9197c35f72d9b2529c8581c17350207f3c0fL11-R35): Restructured pipeline to use `blocks` instead of `global_job_config`, added `after_pipeline` tasks for generating pipeline reports, and removed redundant `cache store` commands.
* [`.semaphore/publish_to_mavencentral.yml`](diffhunk://#diff-e5c5695bcbd8e94675585586123b2edb6d8be37da0f5655439f25f3957e0f3efL11-R19): Simplified pipeline structure by removing `global_job_config` and moving environment variables and prologue commands into `blocks`.
* [`.semaphore/semaphore.yml`](diffhunk://#diff-f4c421dab68fb568a2a5f47b7851a85a409574b05f841f635bad1880b82db03bR44-R49): Added `auto_promote` rules for publishing pipelines, enabling automatic promotion when the pipeline passes and a tag matches the specified pattern.

### Maven Metadata Enhancements:
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R127-R143): Added a `name` field, developer information, and configured Maven plugins (`maven-source-plugin` and `maven-javadoc-plugin`) to generate source and Javadoc JARs for better integration with Maven Central. [[1]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R127-R143) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R223-R252)