### PR TITLE
CPCG-112-add support for non json key value

### DIFF
--- a/aws/src/main/java/io/confluent/csid/config/provider/aws/SecretsManagerConfigProvider.java
+++ b/aws/src/main/java/io/confluent/csid/config/provider/aws/SecretsManagerConfigProvider.java
@@ -136,7 +136,6 @@ import software.amazon.awssdk.core.SdkBytes;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.Map;
 
 @Description("This config provider is used to retrieve secrets from the AWS Secrets Manager service.")

--- a/aws/src/main/java/io/confluent/csid/config/provider/aws/SecretsManagerConfigProvider.java
+++ b/aws/src/main/java/io/confluent/csid/config/provider/aws/SecretsManagerConfigProvider.java
@@ -193,7 +193,7 @@ public class SecretsManagerConfigProvider extends AbstractJacksonConfigProvider<
       }
       secretString = StandardCharsets.UTF_8.decode(result.secretBinary().asByteBuffer()).toString();
     }
-    return config.isPlainSecret() ? Map.of(secretRequest.path(), secretString) : readJsonValue(secretString);
+    return config.isJsonSecret() ? readJsonValue(secretString) : Map.of(secretRequest.path(), secretString);
   }
 
   @Override

--- a/aws/src/main/java/io/confluent/csid/config/provider/aws/SecretsManagerConfigProviderConfig.java
+++ b/aws/src/main/java/io/confluent/csid/config/provider/aws/SecretsManagerConfigProviderConfig.java
@@ -150,8 +150,8 @@ public class SecretsManagerConfigProviderConfig extends AbstractConfigProviderCo
   public static final String ENDPOINT_OVERRIDE_DOC = "The value to override the service address used by Secrets Manager Client.  See `Developer " +
       "Guide <https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/using.html>` for more details.";
 
-  public static final String USE_JSON_CONFIG = "use.json";
-  static final String USE_JSON_DOC = "Whether the secret is a json object. If true, the secret will be parsed as a json object and the keys will be used as the config keys.";
+  public static final String SECRET_FORMAT_PLAIN = "secret.format.plain";
+  static final String SECRET_FORMAT_PLAIN_DOC = "Whether the format of the secret is plain. If false, the secret will be parsed as a json object and the keys will be used as the config keys.";
 
   public final String region;
   public final long minimumSecretTTL;
@@ -217,15 +217,15 @@ public class SecretsManagerConfigProviderConfig extends AbstractConfigProviderCo
                 .defaultValue("")
                 .build()
         ).define(
-                 ConfigKeyBuilder.of(USE_JSON_CONFIG, ConfigDef.Type.BOOLEAN)
-                 .documentation(USE_JSON_DOC)
+                 ConfigKeyBuilder.of(SECRET_FORMAT_PLAIN, ConfigDef.Type.BOOLEAN)
+                 .documentation(SECRET_FORMAT_PLAIN_DOC)
                  .importance(ConfigDef.Importance.MEDIUM)
-                 .defaultValue(true)
+                 .defaultValue(false)
                  .build()
         );
   }
 
-  public boolean isJsonSecret() {
-    return getBoolean(USE_JSON_CONFIG);
+  public boolean isPlainSecret() {
+    return getBoolean(SECRET_FORMAT_PLAIN);
   }
 }

--- a/aws/src/main/java/io/confluent/csid/config/provider/aws/SecretsManagerConfigProviderConfig.java
+++ b/aws/src/main/java/io/confluent/csid/config/provider/aws/SecretsManagerConfigProviderConfig.java
@@ -150,8 +150,8 @@ public class SecretsManagerConfigProviderConfig extends AbstractConfigProviderCo
   public static final String ENDPOINT_OVERRIDE_DOC = "The value to override the service address used by Secrets Manager Client.  See `Developer " +
       "Guide <https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/using.html>` for more details.";
 
-  public static final String SECRET_FORMAT_PLAIN = "secret.format.plain";
-  static final String SECRET_FORMAT_PLAIN_DOC = "Whether the format of the secret is plain. If false, the secret will be parsed as a json object and the keys will be used as the config keys.";
+  public static final String USE_JSON_CONFIG = "use.json";
+  static final String USE_JSON_DOC = "If true, the secret will be parsed as a json object and the keys will be used as the config keys.";
 
   public final String region;
   public final long minimumSecretTTL;
@@ -217,15 +217,15 @@ public class SecretsManagerConfigProviderConfig extends AbstractConfigProviderCo
                 .defaultValue("")
                 .build()
         ).define(
-                 ConfigKeyBuilder.of(SECRET_FORMAT_PLAIN, ConfigDef.Type.BOOLEAN)
-                 .documentation(SECRET_FORMAT_PLAIN_DOC)
+                 ConfigKeyBuilder.of(USE_JSON_CONFIG, ConfigDef.Type.BOOLEAN)
+                 .documentation(USE_JSON_DOC)
                  .importance(ConfigDef.Importance.MEDIUM)
-                 .defaultValue(false)
+                 .defaultValue(true)
                  .build()
         );
   }
 
-  public boolean isPlainSecret() {
-    return getBoolean(SECRET_FORMAT_PLAIN);
+  public boolean isJsonSecret() {
+    return getBoolean(USE_JSON_CONFIG);
   }
 }

--- a/aws/src/main/java/io/confluent/csid/config/provider/aws/SecretsManagerConfigProviderConfig.java
+++ b/aws/src/main/java/io/confluent/csid/config/provider/aws/SecretsManagerConfigProviderConfig.java
@@ -150,6 +150,9 @@ public class SecretsManagerConfigProviderConfig extends AbstractConfigProviderCo
   public static final String ENDPOINT_OVERRIDE_DOC = "The value to override the service address used by Secrets Manager Client.  See `Developer " +
       "Guide <https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/using.html>` for more details.";
 
+  public static final String USE_JSON_CONFIG = "use.json";
+  static final String USE_JSON_DOC = "Whether the secret is a json object. If true, the secret will be parsed as a json object and the keys will be used as the config keys.";
+
   public final String region;
   public final long minimumSecretTTL;
   public final AwsCredentials credentials;
@@ -213,6 +216,16 @@ public class SecretsManagerConfigProviderConfig extends AbstractConfigProviderCo
                 .importance(ConfigDef.Importance.LOW)
                 .defaultValue("")
                 .build()
+        ).define(
+                 ConfigKeyBuilder.of(USE_JSON_CONFIG, ConfigDef.Type.BOOLEAN)
+                 .documentation(USE_JSON_DOC)
+                 .importance(ConfigDef.Importance.MEDIUM)
+                 .defaultValue(true)
+                 .build()
         );
+  }
+
+  public boolean isJsonSecret() {
+    return getBoolean(USE_JSON_CONFIG);
   }
 }

--- a/aws/src/test/java/io/confluent/csid/config/provider/aws/SecretsManagerConfigProviderIT.java
+++ b/aws/src/test/java/io/confluent/csid/config/provider/aws/SecretsManagerConfigProviderIT.java
@@ -143,7 +143,7 @@ import static io.confluent.csid.config.provider.aws.SecretsManagerConfigProvider
 import static io.confluent.csid.config.provider.aws.SecretsManagerConfigProviderConfig.ENDPOINT_OVERRIDE;
 import static io.confluent.csid.config.provider.aws.SecretsManagerConfigProviderConfig.PREFIX_CONFIG;
 import static io.confluent.csid.config.provider.aws.SecretsManagerConfigProviderConfig.REGION_CONFIG;
-import static io.confluent.csid.config.provider.aws.SecretsManagerConfigProviderConfig.USE_JSON_CONFIG;
+import static io.confluent.csid.config.provider.aws.SecretsManagerConfigProviderConfig.SECRET_FORMAT_PLAIN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -164,12 +164,12 @@ public class SecretsManagerConfigProviderIT {
     provider = new SecretsManagerConfigProvider();
   }
 
-  private static void configureProvider(boolean useJsonConfig) {
+  private static void configureProvider(boolean isSecretFormatPlain) {
     provider.configure(ImmutableMap.of(ENDPOINT_OVERRIDE, localstack.getEndpoint().toString(),
             REGION_CONFIG, localstack.getRegion(),
             AWS_ACCESS_KEY_ID_CONFIG, localstack.getAccessKey(),
             AWS_SECRET_KEY_CONFIG, localstack.getSecretKey(),
-            USE_JSON_CONFIG, useJsonConfig));
+            SECRET_FORMAT_PLAIN, isSecretFormatPlain));
   }
 
   @AfterAll
@@ -180,7 +180,7 @@ public class SecretsManagerConfigProviderIT {
 
   @Test
   public void get() {
-    configureProvider(true);
+    configureProvider(false);
     try (SecretsManagerClient secretsManagerClient = SecretsManagerClient.builder()
             .endpointOverride(localstack.getEndpoint())
             .credentialsProvider(StaticCredentialsProvider.create(
@@ -209,8 +209,8 @@ public class SecretsManagerConfigProviderIT {
   }
 
   @Test
-  public void getNoJson() {
-    configureProvider(false);
+  public void getPlainSecretValue() {
+    configureProvider(true);
     try (SecretsManagerClient secretsManagerClient = SecretsManagerClient.builder()
             .endpointOverride(localstack.getEndpoint())
             .credentialsProvider(StaticCredentialsProvider.create(
@@ -236,7 +236,7 @@ public class SecretsManagerConfigProviderIT {
 
   @Test
   public void getBinary() {
-    configureProvider(true);
+    configureProvider(false);
     try (SecretsManagerClient secretsManagerClient = SecretsManagerClient.builder()
             .endpointOverride(localstack.getEndpoint())
             .credentialsProvider(StaticCredentialsProvider.create(
@@ -265,7 +265,7 @@ public class SecretsManagerConfigProviderIT {
 
   @Test
   public void getWithPrefix() {
-    configureProvider(true);
+    configureProvider(false);
     try (SecretsManagerClient secretsManagerClient = SecretsManagerClient.builder()
             .endpointOverride(localstack.getEndpoint())
             .credentialsProvider(StaticCredentialsProvider.create(

--- a/aws/src/test/java/io/confluent/csid/config/provider/aws/SecretsManagerConfigProviderIT.java
+++ b/aws/src/test/java/io/confluent/csid/config/provider/aws/SecretsManagerConfigProviderIT.java
@@ -143,7 +143,7 @@ import static io.confluent.csid.config.provider.aws.SecretsManagerConfigProvider
 import static io.confluent.csid.config.provider.aws.SecretsManagerConfigProviderConfig.ENDPOINT_OVERRIDE;
 import static io.confluent.csid.config.provider.aws.SecretsManagerConfigProviderConfig.PREFIX_CONFIG;
 import static io.confluent.csid.config.provider.aws.SecretsManagerConfigProviderConfig.REGION_CONFIG;
-import static io.confluent.csid.config.provider.aws.SecretsManagerConfigProviderConfig.SECRET_FORMAT_PLAIN;
+import static io.confluent.csid.config.provider.aws.SecretsManagerConfigProviderConfig.USE_JSON_CONFIG;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -164,12 +164,12 @@ public class SecretsManagerConfigProviderIT {
     provider = new SecretsManagerConfigProvider();
   }
 
-  private static void configureProvider(boolean isSecretFormatPlain) {
+  private static void configureProvider(boolean useJsonConfig) {
     provider.configure(ImmutableMap.of(ENDPOINT_OVERRIDE, localstack.getEndpoint().toString(),
             REGION_CONFIG, localstack.getRegion(),
             AWS_ACCESS_KEY_ID_CONFIG, localstack.getAccessKey(),
             AWS_SECRET_KEY_CONFIG, localstack.getSecretKey(),
-            SECRET_FORMAT_PLAIN, isSecretFormatPlain));
+            USE_JSON_CONFIG, useJsonConfig));
   }
 
   @AfterAll
@@ -180,7 +180,7 @@ public class SecretsManagerConfigProviderIT {
 
   @Test
   public void get() {
-    configureProvider(false);
+    configureProvider(true);
     try (SecretsManagerClient secretsManagerClient = SecretsManagerClient.builder()
             .endpointOverride(localstack.getEndpoint())
             .credentialsProvider(StaticCredentialsProvider.create(
@@ -210,7 +210,7 @@ public class SecretsManagerConfigProviderIT {
 
   @Test
   public void getPlainSecretValue() {
-    configureProvider(true);
+    configureProvider(false);
     try (SecretsManagerClient secretsManagerClient = SecretsManagerClient.builder()
             .endpointOverride(localstack.getEndpoint())
             .credentialsProvider(StaticCredentialsProvider.create(
@@ -236,7 +236,7 @@ public class SecretsManagerConfigProviderIT {
 
   @Test
   public void getBinary() {
-    configureProvider(false);
+    configureProvider(true);
     try (SecretsManagerClient secretsManagerClient = SecretsManagerClient.builder()
             .endpointOverride(localstack.getEndpoint())
             .credentialsProvider(StaticCredentialsProvider.create(
@@ -265,7 +265,7 @@ public class SecretsManagerConfigProviderIT {
 
   @Test
   public void getWithPrefix() {
-    configureProvider(false);
+    configureProvider(true);
     try (SecretsManagerClient secretsManagerClient = SecretsManagerClient.builder()
             .endpointOverride(localstack.getEndpoint())
             .credentialsProvider(StaticCredentialsProvider.create(


### PR DESCRIPTION
Adding support in aws provider for non json key/values.

## Description
Aws secret provider currently supports only json formatted values, this adds support for plain values, where the key will be the secret name and the value will be the complete secret value.

## Motivation and Context
this change aligns with the requirements for gateway project, where we are documenting support for plain values.

## How Has This Been Tested?
added integration test for the change.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.