### PR TITLE
[CPCG-177] add non-json support in azure key vault

### DIFF
--- a/azure/src/main/java/io/confluent/csid/config/provider/azure/KeyVaultConfigProvider.java
+++ b/azure/src/main/java/io/confluent/csid/config/provider/azure/KeyVaultConfigProvider.java
@@ -187,7 +187,7 @@ public class KeyVaultConfigProvider extends AbstractJacksonConfigProvider<KeyVau
   @Override
   protected Map<String, String> getSecret(SecretRequest secretRequest) throws Exception {
     KeyVaultSecret response = secretClient.getSecret(secretRequest.path(), secretRequest.version().orElse(null));
-    return readJsonValue(response.getValue());
+    return config.isJsonSecret() ? readJsonValue(response.getValue()) : Map.of(secretRequest.path(), response.getValue());
   }
 
 

--- a/azure/src/main/java/io/confluent/csid/config/provider/azure/KeyVaultConfigProviderConfig.java
+++ b/azure/src/main/java/io/confluent/csid/config/provider/azure/KeyVaultConfigProviderConfig.java
@@ -178,6 +178,9 @@ public class KeyVaultConfigProviderConfig extends AbstractConfigProviderConfig {
   public static final String VAULT_URL_CONFIG = "vault.url";
   public static final String VAULT_URL_DOC = "The vault url to connect to. For example `https://example.vault.azure.net/`";
 
+  public static final String USE_JSON_CONFIG = "use.json";
+  static final String USE_JSON_DOC = "If true, the secret will be parsed as a json object and the keys will be used as the config keys.";
+
 
   public final String prefix;
   public final CredentialLocation credentialLocation;
@@ -303,6 +306,12 @@ public class KeyVaultConfigProviderConfig extends AbstractConfigProviderConfig {
                 .importance(ConfigDef.Importance.LOW)
                 .defaultValue("")
                 .build()
+        ).define(
+            ConfigKeyBuilder.of(USE_JSON_CONFIG, ConfigDef.Type.BOOLEAN)
+                .documentation(USE_JSON_DOC)
+                .importance(ConfigDef.Importance.MEDIUM)
+                .defaultValue(true)
+                .build()
         );
   }
 
@@ -394,6 +403,10 @@ public class KeyVaultConfigProviderConfig extends AbstractConfigProviderConfig {
     }
     log.info("Credential Type = {}", result.getClass().getName());
     return result;
+  }
+
+  public boolean isJsonSecret() {
+    return getBoolean(USE_JSON_CONFIG);
   }
 
 }

--- a/azure/src/test/java/io/confluent/csid/config/provider/azure/KeyVaultConfigProviderTest.java
+++ b/azure/src/test/java/io/confluent/csid/config/provider/azure/KeyVaultConfigProviderTest.java
@@ -223,6 +223,34 @@ public class KeyVaultConfigProviderTest {
     assertEquals(expectedData, configData.data());
   }
 
+  @Test
+  public void getPlainSecretValue() throws IOException {
+    // Configure provider with use.json set to false
+    this.settings.put(KeyVaultConfigProviderConfig.USE_JSON_CONFIG, "false");
+    this.provider.configure(this.settings);
+    
+    final String expectedRequestName = "clientId";
+    final String secretName = "clientId";
+    final String plainSecretValue = "mappedClientId/mappedClientSecret";
+    
+    // Mock the secret client to return a plain string value
+    when(this.secretClientWrapper.getSecret(any(), any())).thenAnswer(invocationOnMock -> {
+      String actualName = invocationOnMock.getArgument(0);
+      String version = invocationOnMock.getArgument(1);
+      assertEquals(expectedRequestName, actualName);
+      assertEquals(null, version);
+      return new KeyVaultSecret(expectedRequestName, plainSecretValue);
+    });
+
+    Map<String, String> expectedData = ImmutableMap.of(
+        "clientId", "mappedClientId/mappedClientSecret"
+    );
+    
+    ConfigData configData = this.provider.get(secretName, ImmutableSet.of());
+    assertNotNull(configData);
+    assertEquals(expectedData, configData.data());
+  }
+
 
 //  @Test
 //  public void getPrefixed() throws IOException {


### PR DESCRIPTION
Adding support in azure provider for non json key/values.

Description
Azure key provider currently supports only json formatted values, this adds support for plain values, where the key will be the secret name and the value will be the complete secret value.

Motivation and Context
this change aligns with the requirements for gateway project, where we are documenting support for plain values.

How Has This Been Tested?
- added integration test for the change.
- tested manually

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.