### PR TITLE
feat: migrate from OSSRH to Central Publishing Portal

### DIFF
--- a/.semaphore/publish_to_mavencentral.yml
+++ b/.semaphore/publish_to_mavencentral.yml
@@ -30,9 +30,9 @@ blocks:
             - . vault-sem-get-secret v1/ci/kv/semaphore2/gpg/confluent-packaging-private-8B1DA6120C2BF624
             - chmod +x .semaphore/initgpg.sh
             - . .semaphore/initgpg.sh
-            - export SONATYPE_SERVER_ID=ossrh
-            - export SONATYPE_OSSRH_USER=$(vault kv get --field=user_token_username v1/ci/kv/sonatype/confluent)
-            - export SONATYPE_OSSRH_PASSWORD=$(vault kv get --field=user_token_password v1/ci/kv/sonatype/confluent)
+            - export SONATYPE_SERVER_ID=central
+            - export CENTRAL_TOKEN_USERNAME=$(vault kv get --field=user_token_username v1/ci/kv/sonatype/confluent)
+            - export CENTRAL_TOKEN_PASSWORD=$(vault kv get --field=user_token_password v1/ci/kv/sonatype/confluent)
             - export SETTINGS_XML_PATH="$HOME/.m2/settings.xml"
             - python .semaphore/update_maven_settings.py # Update maven settings with Sonatype credentials
             - ./mvnw --batch-mode clean deploy -Ppublish-to-central -Dgpg.passphrase=$PASSPHRASE -DskipTests

--- a/.semaphore/update_maven_settings.py
+++ b/.semaphore/update_maven_settings.py
@@ -4,8 +4,8 @@ import xml.dom.minidom
 
 
 def get_environment_variables():
-    username = os.getenv("SONATYPE_OSSRH_USER")
-    password = os.getenv("SONATYPE_OSSRH_PASSWORD")
+    username = os.getenv("CENTRAL_TOKEN_USERNAME")
+    password = os.getenv("CENTRAL_TOKEN_PASSWORD")
     server_id = os.getenv("SONATYPE_SERVER_ID")
     settings_xml_path = os.getenv("SETTINGS_XML_PATH")
 

--- a/pom.xml
+++ b/pom.xml
@@ -197,18 +197,34 @@
     </profile>
     <profile>
       <id>publish-to-central</id>
-      <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-      </distributionManagement>
       <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.3.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.10.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
@@ -224,15 +240,17 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.7.0</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                </configuration>
+              <groupId>org.sonatype.central</groupId>
+              <artifactId>central-publishing-maven-plugin</artifactId>
+              <version>0.8.0</version>
+              <extensions>true</extensions>
+              <configuration>
+                <publishingServerId>central</publishingServerId>
+                <autoPublish>true</autoPublish>
+                <waitUntil>published</waitUntil>
+                <username>${env.CENTRAL_TOKEN_USERNAME}</username>
+                <password>${env.CENTRAL_TOKEN_PASSWORD}</password>
+              </configuration>
             </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
This pull request updates the Maven Central publishing pipeline to use the new Central Publishing plugin and credentials, replacing the legacy OSSRH approach. It also adds plugins to generate source and Javadoc JARs as part of the publishing process.

**Migration to new Maven Central publishing system:**

* Updated `.semaphore/publish_to_mavencentral.yml` to use new environment variables (`CENTRAL_TOKEN_USERNAME`, `CENTRAL_TOKEN_PASSWORD`, and `SONATYPE_SERVER_ID=central`) instead of the old OSSRH variables, aligning with the new publishing flow.
* Modified `.semaphore/update_maven_settings.py` to reference the new environment variables for authentication.

**`pom.xml` publishing configuration changes:**

* Removed the old `distributionManagement` section for OSSRH and replaced the `nexus-staging-maven-plugin` with the new `central-publishing-maven-plugin`, updating configuration to use the new credentials and publishing server ID. 
* Added the `maven-source-plugin` and `maven-javadoc-plugin` to the `publish-to-central` profile to ensure source and Javadoc JARs are attached during deployment.