### PR TITLE
fix(pom): add name to module POMs for Central validation

### DIFF
--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -7,6 +7,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>csid-secrets-provider-annotations</artifactId>
+    <name>${project.artifactId}</name>
     <parent>
         <groupId>io.confluent.csid</groupId>
         <artifactId>csid-secrets-providers</artifactId>

--- a/aws/pom.xml
+++ b/aws/pom.xml
@@ -121,6 +121,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>csid-secrets-provider-aws</artifactId>
+    <name>${project.artifactId}</name>
     <parent>
         <groupId>io.confluent.csid</groupId>
         <artifactId>csid-secrets-providers</artifactId>

--- a/azure/pom.xml
+++ b/azure/pom.xml
@@ -121,6 +121,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>csid-secrets-provider-azure</artifactId>
+    <name>${project.artifactId}</name>
     <parent>
         <groupId>io.confluent.csid</groupId>
         <artifactId>csid-secrets-providers</artifactId>

--- a/common-testing/pom.xml
+++ b/common-testing/pom.xml
@@ -7,6 +7,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>csid-secrets-provider-common-testing</artifactId>
+    <name>${project.artifactId}</name>
     <parent>
         <groupId>io.confluent.csid</groupId>
         <artifactId>csid-secrets-providers</artifactId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -7,6 +7,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>csid-secrets-provider-common</artifactId>
+    <name>${project.artifactId}</name>
     <parent>
         <groupId>io.confluent.csid</groupId>
         <artifactId>csid-secrets-providers</artifactId>

--- a/gcloud/pom.xml
+++ b/gcloud/pom.xml
@@ -121,6 +121,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>csid-secrets-provider-gcloud</artifactId>
+    <name>${project.artifactId}</name>
     <parent>
         <groupId>io.confluent.csid</groupId>
         <artifactId>csid-secrets-providers</artifactId>

--- a/k8s/pom.xml
+++ b/k8s/pom.xml
@@ -121,6 +121,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>csid-secrets-provider-k8s</artifactId>
+    <name>${project.artifactId}</name>
     <parent>
         <groupId>io.confluent.csid</groupId>
         <artifactId>csid-secrets-providers</artifactId>

--- a/vault/pom.xml
+++ b/vault/pom.xml
@@ -121,6 +121,7 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>csid-secrets-provider-vault</artifactId>
+    <name>${project.artifactId}</name>
     <parent>
         <groupId>io.confluent.csid</groupId>
         <artifactId>csid-secrets-providers</artifactId>


### PR DESCRIPTION
This pull request updates the Maven configuration for several modules in the project. The main change is the addition of the `<name>` property to each module's `pom.xml`, which sets the name to the value of the module's artifact ID. This improves project metadata and can help with clarity in build tools and dependency management systems.

Maven configuration improvements:

* Added the `<name>${project.artifactId}</name>` property to the `pom.xml` files of the following modules: `annotations`, `aws`, `azure`, `common-testing`, `common`, `gcloud`, `k8s`, and `vault`, ensuring each module's name is set consistently to its artifact ID.

```
Deployment 9b438f87-8ae1-4d68-b636-a5a77be463df failed05:44
pkg:maven/io.confluent.csid/csid-secrets-provider-aws@1.0.45:05:44
 - Project name is missing05:44
pkg:maven/io.confluent.csid/csid-secrets-provider-k8s@1.0.45:05:44
 - Project name is missing05:44
pkg:maven/io.confluent.csid/csid-secrets-provider-gcloud@1.0.45:05:44
 - Project name is missing05:44
pkg:maven/io.confluent.csid/csid-secrets-provider-azure@1.0.45:05:44
 - Project name is missing05:44
pkg:maven/io.confluent.csid/csid-secrets-provider-vault@1.0.45:05:44
 - Project name is missing05:44
pkg:maven/io.confluent.csid/csid-secrets-provider-common-testing@1.0.45:05:44
 - Project name is missing05:44
pkg:maven/io.confluent.csid/csid-secrets-provider-annotations@1.0.45:05:44
 - Project name is missing05:44
pkg:maven/io.confluent.csid/csid-secrets-provider-common@1.0.45:05:44
 - Project name is missing
```