### PR TITLE
build: restore publish-to-s3 with log4j-free io.confluent:aws-maven wagon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,6 +194,19 @@
   </licenses>
   <profiles>
     <profile>
+      <id>publish-to-s3</id>
+      <distributionManagement>
+        <repository>
+          <id>confluent-csid-repo</id>
+          <url>s3://confluent-csid-maven/releases</url>
+        </repository>
+        <snapshotRepository>
+          <id>confluent-csid-repo</id>
+          <url>s3://confluent-csid-maven/snapshots</url>
+        </snapshotRepository>
+      </distributionManagement>
+    </profile>
+    <profile>
       <id>publish-to-central</id>
       <build>
         <plugins>
@@ -445,6 +458,17 @@
     </dependency>
   </dependencies>
   <build>
+    <extensions>
+      <!-- Log4j-free s3:// wagon (slf4j/logback, excludes commons-logging) used to
+           publish to the public confluent-csid-maven repo (served to customers via
+           CloudFront: maven.csid.confluent.io). Replaces com.github.seahen:maven-s3-wagon,
+           which pulled the now-archived log4j 1.2.17 and broke every build. -->
+      <extension>
+        <groupId>io.confluent</groupId>
+        <artifactId>aws-maven</artifactId>
+        <version>1.0.0</version>
+      </extension>
+    </extensions>
     <pluginManagement>
       <plugins>
         <plugin>


### PR DESCRIPTION
## What
- Restore the `publish-to-s3` profile and add the log4j-free `io.confluent:aws-maven:1.0.0` s3 wagon (top-level build extension).

## Why
csid-secrets-providers artifacts are consumed by external customers via the public CloudFront maven repo (`maven.csid.confluent.io` → `s3://confluent-csid-maven`), so releases must keep publishing to S3. #551 removed the s3 wagon + `publish-to-s3`; this restores them. The old `com.github.seahen:maven-s3-wagon` pulled the now-permanently-archived `log4j 1.2.17` (breaking every build) — `io.confluent:aws-maven:1.0.0` is the Confluent-published, log4j-free replacement (slf4j/logback, commons-logging excluded). Supersedes the (closed) release-to-CodeArtifact approach in csid-ccet-semaphore-pipeline#341.

## Test plan
- `./mvnw validate` → BUILD SUCCESS; the extension resolves and no log4j is pulled.
