### PR TITLE
build: pin remaining netty transport/resolver native modules to 4.2.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -372,6 +372,45 @@
         <artifactId>netty-buffer</artifactId>
         <version>${netty.version}</version>
       </dependency>
+      <!-- Pin the remaining netty transport/resolver native + classes modules to
+           ${netty.version} too. They were floating in transitively at 4.1.x, which
+           leaves stale netty jars in the plugin package that dependency scanners flag
+           against the netty CVE family even though the vulnerable core modules are fixed. -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-epoll</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-kqueue</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-unix-common</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-classes-epoll</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport-classes-kqueue</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-resolver-dns-classes-macos</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-resolver-dns-native-macos</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
       <!-- CVE-2025-55163: Upgraded gRPC Netty shaded transport to 1.75.0 -->
       <dependency>
         <groupId>io.grpc</groupId>


### PR DESCRIPTION
## What
- Pin the remaining netty transport/resolver native + classes modules (`netty-transport-native-epoll/-kqueue/-unix-common`, `netty-transport-classes-epoll/-kqueue`, `netty-resolver-dns-classes-macos/-native-macos`) to `${netty.version}` (4.2.17) in the root pom.

## Why
After #551/#552, the core netty modules were 4.2.17 but these transport/resolver **native/classes helpers** still floated in transitively at 4.1.x — leaving stale netty jars in the plugin package that dependency scanners flag against the netty CVE family even though the vulnerable core modules are fixed. Pinning them makes the whole netty stack 4.2.17 so a customer re-scan comes back fully clean.

## Test plan
- `./mvnw dependency:tree -pl azure -Dincludes=io.netty` → every netty artifact resolves to 4.2.17.Final, **no 4.1.x remaining** (verified against the shipped 1.0.52 Hub package, which still bundled these 4.1.x jars).
