### PR TITLE
fix: remediate netty CVEs in the AWS secrets provider

### DIFF
--- a/aws/pom.xml
+++ b/aws/pom.xml
@@ -142,53 +142,79 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- CVE-2025-55163: Upgraded Netty HTTP/2 codec to 4.1.125.Final -->
-            <!-- CVE-2025-58057: Upgraded Netty codec dependencies to 4.1.125.Final -->
+            <!-- Force every netty module pulled transitively by the AWS SDK (netty-nio-client)
+                 to ${netty.version} (4.2.17.Final, managed in the root pom). These were pinned
+                 at mixed 4.1.x, leaving vulnerable netty jars in the AWS plugin — the same CVE
+                 class remediated for the azure provider. -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http2</artifactId>
-                <version>4.1.136.Final</version>
+                <version>${netty.version}</version>
             </dependency>
-            <!-- Ensure all Netty modules are aligned to 4.1.125.Final for consistency -->
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http</artifactId>
-                <version>4.1.137.Final</version>
+                <version>${netty.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec</artifactId>
-                <version>4.1.136.Final</version>
+                <version>${netty.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport</artifactId>
-                <version>4.1.124.Final</version>
+                <version>${netty.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-buffer</artifactId>
-                <version>4.1.124.Final</version>
+                <version>${netty.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-handler</artifactId>
-                <version>4.1.137.Final</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport-classes-epoll</artifactId>
-                <version>4.1.124.Final</version>
+                <version>${netty.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-resolver</artifactId>
-                <version>4.1.124.Final</version>
+                <version>${netty.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-common</artifactId>
-                <version>4.1.124.Final</version>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-dns</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-resolver-dns</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler-proxy</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-classes-epoll</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-epoll</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-native-unix-common</artifactId>
+                <version>${netty.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## What
- Repoint the AWS provider's netty overrides from mixed 4.1.x to `${netty.version}` (4.2.17) in `aws/pom.xml`.

## Why
The `aws` module pinned netty at mixed 4.1.x versions in its own `dependencyManagement`, overriding the root and shipping vulnerable netty jars in the AWS plugin — the same CVE class remediated for azure in #551. This aligns the AWS SDK's transitive netty to the fixed 4.2.17 line. (gcloud/vault already inherit the root 4.2.17; jackson-databind inherits the root 2.18.8.)

## Test plan
- `./mvnw dependency:tree -pl aws -Dincludes=io.netty` → all netty 4.2.17.Final, no 4.1.x.
- `./mvnw dependency:tree -pl aws -Dincludes=com.fasterxml.jackson.core:jackson-databind` → 2.18.8.
